### PR TITLE
feat: align with Mantine 9.3.2

### DIFF
--- a/packages/@mantine-vue/core/src/components/Checkbox/Checkbox.ts
+++ b/packages/@mantine-vue/core/src/components/Checkbox/Checkbox.ts
@@ -175,11 +175,14 @@ const CheckboxBase = defineComponent({
               variant: props.variant,
               onClick: (event: MouseEvent) => {
                 callHandler(attrs.onClick, event)
-                if (props.readOnly && props.checked === undefined) {
+                if (props.readOnly && checked === undefined) {
                   event.preventDefault()
                 }
               },
               onChange: (event: Event) => {
+                if (props.readOnly) {
+                  return
+                }
                 callHandler(attrs.onChange, event)
                 groupContext?.onChange(event)
               },

--- a/packages/@mantine-vue/core/src/components/HoverCard/HoverCard.context.ts
+++ b/packages/@mantine-vue/core/src/components/HoverCard/HoverCard.context.ts
@@ -2,6 +2,7 @@ import { createSafeContext } from '../../core'
 export interface HoverCardContextValue {
   openDropdown: () => void
   closeDropdown: () => void
+  assignTarget: (node: HTMLElement | null) => void
 }
 export const [provideHoverCardContext, useHoverCardContext] =
   createSafeContext<HoverCardContextValue>('HoverCard component was not found in the tree')

--- a/packages/@mantine-vue/core/src/components/HoverCard/HoverCard.ts
+++ b/packages/@mantine-vue/core/src/components/HoverCard/HoverCard.ts
@@ -34,6 +34,7 @@ const HoverCardBase = defineComponent({
     provideHoverCardContext({
       openDropdown: state.openDropdown,
       closeDropdown: state.closeDropdown,
+      assignTarget: state.assignTarget,
     })
     return () =>
       h(Popover, { ...attrs, opened: state.opened.value, __staticSelector: 'HoverCard' }, slots)

--- a/packages/@mantine-vue/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.ts
+++ b/packages/@mantine-vue/core/src/components/HoverCard/HoverCardTarget/HoverCardTarget.ts
@@ -1,4 +1,5 @@
 import { cloneVNode, defineComponent, h, type VNode } from 'vue'
+import { mergeRefs } from '@mantine-vue/hooks'
 import { PopoverTarget } from '../../Popover'
 import { useHoverCardContext } from '../HoverCard.context'
 
@@ -16,20 +17,25 @@ export const HoverCardTarget = defineComponent({
   props: { refProp: { type: String, default: 'ref' }, eventPropsWrapperName: String },
   setup(props, { attrs, slots }) {
     const ctx = useHoverCardContext()
+    const assignTargetRef = (el: any) => {
+      ctx.assignTarget((el?.$el ?? el ?? null) as HTMLElement | null)
+    }
     return () => {
       const child = one(slots)
       const events = { onMouseenter: ctx.openDropdown, onMouseleave: ctx.closeDropdown }
+      const targetRef = mergeRefs(assignTargetRef, (child as any).ref)
       const cloned = cloneVNode(
         child,
         props.eventPropsWrapperName
           ? {
+              ref: targetRef,
               [props.eventPropsWrapperName]: {
                 ...(child.props as any)?.[props.eventPropsWrapperName],
                 ...events,
               },
             }
-          : events,
-        true,
+          : { ref: targetRef, ...events },
+        false,
       )
       return h(PopoverTarget, { ...attrs, refProp: props.refProp }, () => cloned)
     }

--- a/packages/@mantine-vue/core/src/components/HoverCard/use-hover-card.ts
+++ b/packages/@mantine-vue/core/src/components/HoverCard/use-hover-card.ts
@@ -1,4 +1,4 @@
-import { inject, onBeforeUnmount, ref } from 'vue'
+import { inject, onBeforeUnmount, ref, watch } from 'vue'
 import { HoverCardGroupKey } from './HoverCardGroup/HoverCardGroup'
 
 export function useHoverCard(settings: {
@@ -10,6 +10,10 @@ export function useHoverCard(settings: {
 }) {
   const group = inject(HoverCardGroupKey, { withinGroup: false, openDelay: 0, closeDelay: 0 })
   const opened = ref(!!settings.defaultOpened)
+  const targetRef = ref<HTMLElement | null>(null)
+  const assignTarget = (node: HTMLElement | null) => {
+    targetRef.value = node
+  }
   let openTimer: ReturnType<typeof setTimeout> | undefined
   let closeTimer: ReturnType<typeof setTimeout> | undefined
   const clear = () => {
@@ -34,6 +38,35 @@ export function useHoverCard(settings: {
     if (delay) closeTimer = setTimeout(() => change(false), delay)
     else change(false)
   }
-  onBeforeUnmount(clear)
-  return { opened, openDropdown, closeDropdown }
+  // When the hovercard is open, watch the target element: if it becomes
+  // disconnected from the DOM or is hidden (no client rects), close the
+  // dropdown so it does not linger without a visible anchor.
+  let observer: IntersectionObserver | undefined
+  const stopObserver = () => {
+    observer?.disconnect()
+    observer = undefined
+  }
+  watch(
+    [opened, targetRef],
+    ([isOpened, node]) => {
+      stopObserver()
+      if (!isOpened || group.withinGroup || typeof IntersectionObserver === 'undefined' || !node) {
+        return
+      }
+      observer = new IntersectionObserver(() => {
+        if (!node.isConnected || node.getClientRects().length === 0) {
+          clear()
+          change(false)
+        }
+      })
+      observer.observe(node)
+    },
+    { flush: 'post' },
+  )
+
+  onBeforeUnmount(() => {
+    clear()
+    stopObserver()
+  })
+  return { opened, openDropdown, closeDropdown, assignTarget }
 }

--- a/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
+++ b/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
@@ -196,6 +196,7 @@ export const PasswordInput = defineComponent({
               Input,
               {
                 component: 'div',
+                dir: attrs.dir as any,
                 error: props.error ?? (slots.error ? true : undefined),
                 leftSection: props.leftSection,
                 size: props.size,

--- a/packages/@mantine-vue/dates/src/index.ts
+++ b/packages/@mantine-vue/dates/src/index.ts
@@ -2165,9 +2165,15 @@ export const SpinInput = defineComponent({
 
     const handleKeydown = (event: KeyboardEvent) => {
       if (props.readOnly) return
-      if (event.key === '0' && props.value === 0) {
-        event.preventDefault()
-        props.onNextInput?.()
+      if (event.key === '0' || event.key === 'Num0') {
+        const target = event.currentTarget as HTMLInputElement
+        const { selectionStart, selectionEnd, value: inputValue } = target
+        const isEntireValueSelected =
+          inputValue.length > 0 && selectionStart === 0 && selectionEnd === inputValue.length
+        if (props.value === 0 && !isEntireValueSelected) {
+          event.preventDefault()
+          props.onNextInput?.()
+        }
       }
       if (event.key === 'Home') {
         event.preventDefault()
@@ -2322,6 +2328,7 @@ export const TimePicker = defineComponent({
     readOnly: Boolean,
     size: { type: [String, Number], default: 'sm' },
     presets: Array as PropType<Array<{ value: string; label: string }>>,
+    closeDropdownOnPresetSelect: Boolean,
     // A ref object supplied by the parent (e.g. DateTimePicker) that gets
     // populated with the actual hours <input> DOM node, so the parent can
     // call .focus() on it directly to auto-focus the time input after a
@@ -2452,6 +2459,13 @@ export const TimePicker = defineComponent({
 
     const opened = ref(false)
 
+    const handlePresetSelect = (timeString: string) => {
+      setValue(timeString)
+      if (props.closeDropdownOnPresetSelect) {
+        opened.value = false
+      }
+    }
+
     return () =>
       h(
         Popover,
@@ -2565,7 +2579,11 @@ export const TimePicker = defineComponent({
                     props.presets?.map((preset) =>
                       h(
                         Button,
-                        { size: 'xs', variant: 'light', onClick: () => setValue(preset.value) },
+                        {
+                          size: 'xs',
+                          variant: 'light',
+                          onClick: () => handlePresetSelect(preset.value),
+                        },
                         () => preset.label,
                       ),
                     ),


### PR DESCRIPTION
Port applicable @mantine/core and @mantine/dates fixes from Mantine 9.3.2 to Mantine Vue.

- Checkbox: ignore onChange and skip preventDefault correctly for readOnly controlled/group checkboxes
- TimePicker: add closeDropdownOnPresetSelect prop
- SpinInput: allow typing 0 when the whole value is selected
- PasswordInput: forward dir to the Input wrapper so sections stay positioned when dir overrides parent direction
- HoverCard: auto-close when the target is removed/hidden while open