### PR TITLE
[@mantine-vue/core] Fixed the Popover arrow placement

### DIFF
--- a/packages/@mantine-vue/core/src/components/Popover/Popover.ts
+++ b/packages/@mantine-vue/core/src/components/Popover/Popover.ts
@@ -3,12 +3,17 @@ import {
   autoUpdate,
   flip,
   hide,
+  inline,
   limitShift,
   offset,
   shift,
   size,
   useFloating,
+  type FlipOptions,
+  type InlineOptions,
   type Middleware,
+  type ShiftOptions,
+  type SizeOptions,
 } from '@floating-ui/vue'
 import {
   cloneVNode,
@@ -61,7 +66,7 @@ export interface PopoverProps {
   onOpen?: () => void
   onClose?: () => void
   onDismiss?: () => void
-  width?: string | number | 'target' | null
+  width?: PopoverWidth
   withArrow?: boolean
   arrowSize?: number
   arrowOffset?: number
@@ -79,7 +84,7 @@ export interface PopoverProps {
   transitionProps?: Record<string, any>
   zIndex?: string | number
   floatingStrategy?: FloatingStrategy
-  middlewares?: Record<string, any>
+  middlewares?: PopoverMiddlewares
   id?: string
   targetProps?: Record<string, any>
   withOverlay?: boolean
@@ -90,6 +95,14 @@ export interface PopoverProps {
   styles?: any
   vars?: any
   unstyled?: boolean
+}
+
+export type PopoverWidth = 'target' | string | number | null
+export interface PopoverMiddlewares {
+  shift?: boolean | ShiftOptions
+  flip?: boolean | FlipOptions
+  inline?: boolean | InlineOptions
+  size?: boolean | SizeOptions
 }
 
 const defaults = {
@@ -390,7 +403,13 @@ const PopoverBase = defineComponent({
             }
           }),
         )
-      result.push(arrow({ element: arrowElement }))
+      if (props.middlewares?.inline)
+        result.push(
+          inline(
+            typeof props.middlewares.inline === 'object' ? props.middlewares.inline : undefined,
+          ),
+        )
+      result.push(arrow({ element: arrowElement, padding: props.arrowOffset }))
       if (props.middlewares?.size || props.width === 'target')
         result.push(
           size({

--- a/packages/@mantine-vue/core/src/components/Popover/index.ts
+++ b/packages/@mantine-vue/core/src/components/Popover/index.ts
@@ -6,4 +6,6 @@ export type {
   PopoverTargetProps,
   PopoverDropdownProps,
   PopoverContextMenuProps,
+  PopoverMiddlewares,
+  PopoverWidth,
 } from './Popover'

--- a/packages/@mantine-vue/core/src/components/__tests__/floating-utils.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/floating-utils.test.ts
@@ -39,11 +39,41 @@ describe('@mantine-vue/core Floating utilities', () => {
       dir: 'ltr',
     })
     expect(centered.transform).toBe('rotate(45deg)')
-    expect(centered.bottom).toBe(-3.5)
+    expect(centered.bottom).toBe('-3.5px')
     expect(merged.clipPath).toBeDefined()
+    expect(merged.top).toBe('-7px')
+    expect(merged.left).toBe('0px')
     expect(getArrowMergeDropdownStyles({ position: 'bottom-start', dir: 'ltr' })).toEqual({
       borderTopLeftRadius: 0,
     })
+  })
+
+  it.each([
+    ['top', { bottom: '-3.5px', left: '10px' }],
+    ['top-start', { bottom: '-3.5px', left: '5px' }],
+    ['top-end', { bottom: '-3.5px', right: '5px' }],
+    ['bottom', { top: '-3.5px', left: '10px' }],
+    ['bottom-start', { top: '-3.5px', left: '5px' }],
+    ['bottom-end', { top: '-3.5px', right: '5px' }],
+    ['left', { right: '-3.5px', top: '10px' }],
+    ['left-start', { right: '-3.5px', top: '5px' }],
+    ['left-end', { right: '-3.5px', bottom: '5px' }],
+    ['right', { left: '-3.5px', top: '10px' }],
+    ['right-start', { left: '-3.5px', top: '5px' }],
+    ['right-end', { left: '-3.5px', bottom: '5px' }],
+  ] as const)('positions the arrow for %s placement', (position, expectedStyles) => {
+    const styles = getArrowPositionStyles({
+      position,
+      arrowSize: 7,
+      arrowOffset: 5,
+      arrowRadius: 0,
+      arrowPosition: 'side',
+      arrowX: 10,
+      arrowY: 10,
+      dir: 'ltr',
+    })
+
+    expect(styles).toMatchObject(expectedStyles)
   })
 
   it('opens context menus at a virtual cursor reference', async () => {

--- a/packages/@mantine-vue/core/src/components/__tests__/popover.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/popover.test.ts
@@ -68,9 +68,19 @@ describe('@mantine-vue/core Popover', () => {
     expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
   })
 
-  it('renders arrow and exposes compound components', () => {
+  it('does not render arrow by default', () => {
+    const wrapper = render({ defaultOpened: true })
+    expect(wrapper.find('.mantine-Popover-arrow').exists()).toBe(false)
+  })
+
+  it('renders and styles arrow when withArrow is set', () => {
     const wrapper = render({ defaultOpened: true, withArrow: true })
-    expect(wrapper.find('.mantine-Popover-arrow').exists()).toBe(true)
+    const arrow = wrapper.find('.mantine-Popover-arrow')
+    expect(arrow.exists()).toBe(true)
+    expect(arrow.attributes('role')).toBe('presentation')
+    expect(arrow.attributes('style')).toContain('width: 7px')
+    expect(arrow.attributes('style')).toContain('height: 7px')
+    expect(arrow.attributes('style')).toContain('top: -3.5px')
     expect(Popover.Target).toBe(PopoverTarget)
     expect(Popover.Dropdown).toBe(PopoverDropdown)
     expect(Popover.ContextMenu).toBe(PopoverContextMenu)

--- a/packages/@mantine-vue/core/src/utils/Floating/FloatingArrow/FloatingArrow.ts
+++ b/packages/@mantine-vue/core/src/utils/Floating/FloatingArrow/FloatingArrow.ts
@@ -21,6 +21,7 @@ export const FloatingArrow = defineComponent({
     return () =>
       props.visible
         ? h('div', {
+            role: 'presentation',
             ...attrs,
             style: [attrs.style, getArrowPositionStyles({ ...props, dir: dir.value })],
           })

--- a/packages/@mantine-vue/core/src/utils/Floating/FloatingArrow/get-arrow-position-styles.ts
+++ b/packages/@mantine-vue/core/src/utils/Floating/FloatingArrow/get-arrow-position-styles.ts
@@ -1,14 +1,18 @@
 import type { CSSProperties } from 'vue'
 import type { ArrowPosition, FloatingPlacement, FloatingPosition, FloatingSide } from '../types'
 
+function px(value: number | undefined) {
+  return value === undefined ? undefined : `${value}px`
+}
+
 function horizontalSide(
   placement: FloatingPlacement | 'center',
   arrowY: number | undefined,
   offset: number,
   position: ArrowPosition,
 ) {
-  if (placement === 'center' || position === 'center') return { top: arrowY }
-  return placement === 'end' ? { bottom: offset } : { top: offset }
+  if (placement === 'center' || position === 'center') return { top: px(arrowY) }
+  return placement === 'end' ? { bottom: px(offset) } : { top: px(offset) }
 }
 function verticalSide(
   placement: FloatingPlacement | 'center',
@@ -17,9 +21,9 @@ function verticalSide(
   position: ArrowPosition,
   dir: 'rtl' | 'ltr',
 ) {
-  if (placement === 'center' || position === 'center') return { left: arrowX }
-  if (placement === 'end') return { [dir === 'ltr' ? 'right' : 'left']: offset }
-  return { [dir === 'ltr' ? 'left' : 'right']: offset }
+  if (placement === 'center' || position === 'center') return { left: px(arrowX) }
+  if (placement === 'end') return { [dir === 'ltr' ? 'right' : 'left']: px(offset) }
+  return { [dir === 'ltr' ? 'left' : 'right']: px(offset) }
 }
 const radiusBySide: Record<FloatingSide, keyof CSSProperties> = {
   bottom: 'borderTopLeftRadius',
@@ -41,8 +45,8 @@ function mergeStyles(
     const startShape = (placement === 'start') !== (dir === 'rtl')
     return {
       ...base,
-      [side === 'bottom' ? 'top' : 'bottom']: -size,
-      [physical]: 0,
+      [side === 'bottom' ? 'top' : 'bottom']: px(-size),
+      [physical]: px(0),
       clipPath:
         side === 'bottom'
           ? startShape
@@ -55,8 +59,8 @@ function mergeStyles(
   }
   return {
     ...base,
-    [side === 'left' ? 'right' : 'left']: -size,
-    [placement === 'start' ? 'top' : 'bottom']: 0,
+    [side === 'left' ? 'right' : 'left']: px(-size),
+    [placement === 'start' ? 'top' : 'bottom']: px(0),
     clipPath:
       side === 'left'
         ? placement === 'start'
@@ -93,7 +97,7 @@ export function getArrowPositionStyles(input: {
     position: 'absolute',
     [radiusBySide[side]]: `${input.arrowRadius}px`,
   }
-  const edge = -input.arrowSize / 2
+  const edge = px(-input.arrowSize / 2)
   if (side === 'left')
     return {
       ...base,


### PR DESCRIPTION
### Changes 

- Converted arrow coordinates to explicit pixel values. Vue was dropping numeric CSS positions, making the arrow invisible.
- Added typed PopoverMiddlewares and PopoverWidth exports.