### PR TITLE
Added named slots to Accordion, ColorInput, Scroller, Splitter, Textarea and PasswordInput

### DIFF
--- a/apps/mantine.dev/src/demos/core/Accordion/Accordion.demo.chevron.ts
+++ b/apps/mantine.dev/src/demos/core/Accordion/Accordion.demo.chevron.ts
@@ -46,12 +46,11 @@ const data = [/* ... */]
 -->
 
 <template>
-  <Accordion
-    defaultValue="Apples"
-    :classNames="{ chevron: classes.chevron }"
-    :chevron="h(PhPlus, { class: classes.icon })"
-    :order="3"
-  >
+  <Accordion defaultValue="Apples" :classNames="{ chevron: classes.chevron }" :order="3">
+    <template #chevron>
+      <PhPlus :class="classes.icon" />
+    </template>
+
     <Accordion.Item v-for="item in data" :key="item.value" :value="item.value">
       <Accordion.Control :icon="item.emoji">{{ item.value }}</Accordion.Control>
       <Accordion.Panel>{{ item.description }}</Accordion.Panel>

--- a/apps/mantine.dev/src/demos/core/Accordion/Accordion.demo.icons.ts
+++ b/apps/mantine.dev/src/demos/core/Accordion/Accordion.demo.icons.ts
@@ -12,21 +12,30 @@ import { PhImage, PhPrinter, PhCamera } from '@phosphor-icons/vue'
 <template>
   <Accordion variant="filled" defaultValue="photos" :order="3">
     <Accordion.Item value="photos">
-      <Accordion.Control :icon="h(PhImage, { size: 22, color: 'var(--mantine-color-dimmed)' })">
+      <Accordion.Control>
+        <template #icon>
+          <PhImage :size="22" color="var(--mantine-color-dimmed)" />
+        </template>
         Recent photos
       </Accordion.Control>
       <Accordion.Panel>Content</Accordion.Panel>
     </Accordion.Item>
 
     <Accordion.Item value="print">
-      <Accordion.Control :icon="h(PhPrinter, { size: 22, color: 'var(--mantine-color-dimmed)' })">
+      <Accordion.Control>
+        <template #icon>
+          <PhPrinter :size="22" color="var(--mantine-color-dimmed)" />
+        </template>
         Print photos
       </Accordion.Control>
       <Accordion.Panel>Content</Accordion.Panel>
     </Accordion.Item>
 
     <Accordion.Item value="camera">
-      <Accordion.Control :icon="h(PhCamera, { size: 22, color: 'var(--mantine-color-dimmed)' })">
+      <Accordion.Control>
+        <template #icon>
+          <PhCamera :size="22" color="var(--mantine-color-dimmed)" />
+        </template>
         Camera settings
       </Accordion.Control>
       <Accordion.Panel>Content</Accordion.Panel>

--- a/apps/mantine.dev/src/demos/core/Alert/Alert.demo.configurator.ts
+++ b/apps/mantine.dev/src/demos/core/Alert/Alert.demo.configurator.ts
@@ -10,7 +10,10 @@ import { PhInfo } from '@phosphor-icons/vue'
 </script>
 
 <template>
-  <Alert{{props}} :icon="h(PhInfo)">
+  <Alert{{props}}>
+    <template #icon>
+      <PhInfo />
+    </template>
     {{children}}
   </Alert>
 </template>

--- a/apps/mantine.dev/src/demos/core/Badge/Badge.demo.sections.ts
+++ b/apps/mantine.dev/src/demos/core/Badge/Badge.demo.sections.ts
@@ -13,6 +13,19 @@ const icon = h(PhAt, { size: 12 })
 
 <template>
   <Group>
+    <Badge>
+      <template #leftSection>
+        <PhAt :size="12" />
+      </template>
+      With left section
+    </Badge>
+    <Badge>
+      <template #rightSection>
+        <PhAt :size="12" />
+      </template>
+      With right section
+    </Badge>
+
     <Badge :leftSection="icon">With left section</Badge>
     <Badge :rightSection="icon">With right section</Badge>
   </Group>

--- a/apps/mantine.dev/src/demos/core/Blockquote/Blockquote.demo.textWrap.ts
+++ b/apps/mantine.dev/src/demos/core/Blockquote/Blockquote.demo.textWrap.ts
@@ -10,7 +10,10 @@ import { PhInfo } from '@phosphor-icons/vue'
 </script>
 
 <template>
-  <Blockquote{{props}} :icon="h(PhInfo)" cite="– Forrest Gump">
+  <Blockquote{{props}} cite="– Forrest Gump">
+    <template #icon>
+      <PhInfo />
+    </template>
     Life is like a box of chocolates. You never know what you are gonna get. But whatever you
     get, you should make the most of it and enjoy every moment.
   </Blockquote>

--- a/apps/mantine.dev/src/demos/core/Blockquote/Blockquote.demo.usage.ts
+++ b/apps/mantine.dev/src/demos/core/Blockquote/Blockquote.demo.usage.ts
@@ -10,7 +10,10 @@ import { PhInfo } from '@phosphor-icons/vue'
 </script>
 
 <template>
-  <Blockquote{{props}} cite="– Forrest Gump" :icon="h(PhInfo)" mt="xl">
+  <Blockquote{{props}} cite="– Forrest Gump" mt="xl">
+    <template #icon>
+      <PhInfo />
+    </template>
     Life is like an npm install – you never know what you are going to get.
   </Blockquote>
 </template>

--- a/apps/mantine.dev/src/demos/core/Card/Card.demo.horizontal.ts
+++ b/apps/mantine.dev/src/demos/core/Card/Card.demo.horizontal.ts
@@ -22,11 +22,14 @@ const stats = [
         :thickness="6"
         :size="150"
         :sections="[{ value: (completed / total) * 100, color: 'blue' }]"
-        :label="h('div', {}, [
-          h(Text, { ta: 'center', fz: 'lg' }, { default: () => ((completed / total) * 100).toFixed(0) + '%' }),
-          h(Text, { ta: 'center', fz: 'xs', c: 'dimmed' }, { default: () => 'Completed' }),
-        ])"
-      />
+      >
+        <template #label>
+          <div>
+            <Text ta="center" fz="lg">{{ ((completed / total) * 100).toFixed(0) }}%</Text>
+            <Text ta="center" fz="xs" c="dimmed">Completed</Text>
+          </div>
+        </template>
+      </RingProgress>
     </Card.Section>
 
     <Card.Section inheritPadding px="md">

--- a/apps/mantine.dev/src/demos/core/Card/Card.demo.section.ts
+++ b/apps/mantine.dev/src/demos/core/Card/Card.demo.section.ts
@@ -27,9 +27,18 @@ const images = [
             </ActionIcon>
           </Menu.Target>
           <Menu.Dropdown>
-            <Menu.Item :leftSection="h(PhFileZip, { size: 14 })">Download zip</Menu.Item>
-            <Menu.Item :leftSection="h(PhEye, { size: 14 })">Preview all</Menu.Item>
-            <Menu.Item :leftSection="h(PhTrash, { size: 14 })" color="red">Delete all</Menu.Item>
+            <Menu.Item>
+              <template #leftSection><PhFileZip :size="14" /></template>
+              Download zip
+            </Menu.Item>
+            <Menu.Item>
+              <template #leftSection><PhEye :size="14" /></template>
+              Preview all
+            </Menu.Item>
+            <Menu.Item color="red">
+              <template #leftSection><PhTrash :size="14" /></template>
+              Delete all
+            </Menu.Item>
           </Menu.Dropdown>
         </Menu>
       </Group>

--- a/apps/mantine.dev/src/demos/core/Chip/Chip.demo.icon.ts
+++ b/apps/mantine.dev/src/demos/core/Chip/Chip.demo.icon.ts
@@ -11,6 +11,14 @@ import { PhX } from '@phosphor-icons/vue'
 </script>
 
 <template>
+  <Chip color="red" variant="filled" defaultChecked>
+    <template #icon>
+      <PhX :size="16" />
+    </template>
+
+    Forbidden
+  </Chip>
+
   <Chip :icon="h(PhX, { size: 16 })" color="red" variant="filled" defaultChecked>
     Forbidden
   </Chip>

--- a/apps/mantine.dev/src/demos/core/CloseButton/CloseButton.demo.icon.ts
+++ b/apps/mantine.dev/src/demos/core/CloseButton/CloseButton.demo.icon.ts
@@ -10,6 +10,12 @@ import { PhXCircle } from '@phosphor-icons/vue'
 </script>
 
 <template>
+  <CloseButton>
+    <template #icon>
+      <PhXCircle :size="18" />
+    </template>
+  </CloseButton>
+
   <CloseButton :icon="h(PhXCircle, { size: 18 })" />
 </template>
 `

--- a/apps/mantine.dev/src/demos/core/ColorInput/ColorInput.demo.eyeDropperIcon.ts
+++ b/apps/mantine.dev/src/demos/core/ColorInput/ColorInput.demo.eyeDropperIcon.ts
@@ -10,10 +10,17 @@ import { ColorInput } from '@mantine-vue/core'
 </script>
 
 <template>
+  <ColorInput label="With custom eye dropper icon" placeholder="Pick color">
+    <template #eyeDropperIcon>
+      <PhCrosshair :size="18" />
+    </template>
+  </ColorInput>
+
   <ColorInput
     :eyeDropperIcon="h(PhCrosshair, { size: 18 })"
     label="With custom eye dropper icon"
     placeholder="Pick color"
+    mt="md"
   />
 </template>
 `

--- a/apps/mantine.dev/src/demos/core/Input/Input.demo.component.ts
+++ b/apps/mantine.dev/src/demos/core/Input/Input.demo.component.ts
@@ -15,12 +15,11 @@ import { Input } from '@mantine-vue/core'
       Button input
     </Input>
 
-    <Input
-      component="select"
-      :rightSection="h(PhCaretDown, { size: 14 })"
-      pointer
-      mt="md"
-    >
+    <Input component="select" pointer mt="md">
+      <template #rightSection>
+        <PhCaretDown :size="14" />
+      </template>
+
       <option value="1">1</option>
       <option value="2">2</option>
     </Input>

--- a/apps/mantine.dev/src/demos/core/Input/Input.demo.sections.ts
+++ b/apps/mantine.dev/src/demos/core/Input/Input.demo.sections.ts
@@ -14,6 +14,11 @@ const value = ref('Clear me')
 
 <template>
   <div>
+    <Input placeholder="Your email">
+      <template #leftSection>
+        <PhAt :size="16" />
+      </template>
+    </Input>
     <Input placeholder="Your email" :leftSection="h(PhAt, { size: 16 })" />
     <Input
       placeholder="Clearable input"

--- a/apps/mantine.dev/src/demos/core/Input/Input.demo.stylesApi.ts
+++ b/apps/mantine.dev/src/demos/core/Input/Input.demo.stylesApi.ts
@@ -10,12 +10,14 @@ import { Input } from '@mantine-vue/core'
 </script>
 
 <template>
-  <Input
-    {{props}}
-    placeholder="Input component"
-    :leftSection="h(PhAt, { size: 16 })"
-    :rightSection="h(PhCaretDown, { size: 16 })"
-  />
+  <Input {{props}} placeholder="Input component">
+    <template #leftSection>
+      <PhAt :size="16" />
+    </template>
+    <template #rightSection>
+      <PhCaretDown :size="16" />
+    </template>
+  </Input>
 </template>
 `
 

--- a/apps/mantine.dev/src/demos/core/List/List.demo.icon.ts
+++ b/apps/mantine.dev/src/demos/core/List/List.demo.icon.ts
@@ -10,19 +10,23 @@ import { List, ThemeIcon } from '@mantine-vue/core'
 </script>
 
 <template>
-  <List
-    spacing="xs"
-    size="sm"
-    center
-    :icon="() => h(ThemeIcon, { color: 'teal', size: 24, radius: 'xl' }, { default: () => h(PhCheckCircle, { size: 16 }) })"
-  >
+  <List spacing="xs" size="sm" center>
+    <template #icon>
+      <ThemeIcon color="teal" :size="24" radius="xl">
+        <PhCheckCircle :size="16" />
+      </ThemeIcon>
+    </template>
+
     <List.Item>Clone or download repository from GitHub</List.Item>
     <List.Item>Install dependencies with yarn</List.Item>
     <List.Item>To start development server run npm start command</List.Item>
     <List.Item>Run tests to make sure your changes do not break the build</List.Item>
-    <List.Item
-      :icon="() => h(ThemeIcon, { color: 'blue', size: 24, radius: 'xl' }, { default: () => h(PhCircleDashed, { size: 16 }) })"
-    >
+    <List.Item>
+      <template #icon>
+        <ThemeIcon color="blue" :size="24" radius="xl">
+          <PhCircleDashed :size="16" />
+        </ThemeIcon>
+      </template>
       Submit a pull request once you are done
     </List.Item>
   </List>

--- a/apps/mantine.dev/src/demos/core/Notification/Notification.demo.icon.ts
+++ b/apps/mantine.dev/src/demos/core/Notification/Notification.demo.icon.ts
@@ -10,7 +10,20 @@ import { Notification } from '@mantine-vue/core'
 </script>
 
 <template>
-  <Notification :icon="h(PhX, { size: 20 })" color="red" title="Bummer!">
+  <Notification color="red" title="Bummer!">
+    <template #icon>
+      <PhX :size="20" />
+    </template>
+    Something went wrong
+  </Notification>
+  <Notification color="teal" title="All good!" mt="md">
+    <template #icon>
+      <PhCheck :size="20" />
+    </template>
+    Everything is fine
+  </Notification>
+
+  <Notification :icon="h(PhX, { size: 20 })" color="red" title="Bummer!" mt="md">
     Something went wrong
   </Notification>
   <Notification :icon="h(PhCheck, { size: 20 })" color="teal" title="All good!" mt="md">

--- a/apps/mantine.dev/src/demos/core/PasswordInput/PasswordInput.demo.visibilityIcon.ts
+++ b/apps/mantine.dev/src/demos/core/PasswordInput/PasswordInput.demo.visibilityIcon.ts
@@ -24,6 +24,20 @@ const VisibilityToggleIcon = defineComponent({
     label="Change visibility toggle icon"
     placeholder="Change visibility toggle icon"
     defaultValue="secret"
+  >
+    <template #visibilityToggleIcon="{ reveal }">
+      <PhEyeSlash v-if="reveal" :size="18" />
+      <PhEye v-else :size="18" />
+    </template>
+  </PasswordInput>
+
+  <PasswordInput
+    maw="320"
+    mx="auto"
+    mt="md"
+    label="Change visibility toggle icon"
+    placeholder="Change visibility toggle icon"
+    defaultValue="secret"
     :visibilityToggleIcon="VisibilityToggleIcon"
   />
 </template>

--- a/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.label.ts
+++ b/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.label.ts
@@ -11,19 +11,21 @@ import { PhCheck } from '@phosphor-icons/vue'
 
 <template>
   <Group justify="center">
-    <RingProgress
-      :sections="[{ value: 40, color: 'blue' }]"
-      :label="h(Text, { c: 'blue', fw: 700, ta: 'center', size: 'xl' }, { default: () => '40%' })"
-    />
+    <RingProgress :sections="[{ value: 40, color: 'blue' }]">
+      <template #label>
+        <Text c="blue" :fw="700" ta="center" size="xl">40%</Text>
+      </template>
+    </RingProgress>
 
-    <RingProgress
-      :sections="[{ value: 100, color: 'teal' }]"
-      :label="h(Center, {}, {
-        default: () => h(ActionIcon, { color: 'teal', variant: 'light', radius: 'xl', size: 'xl' }, {
-          default: () => h(PhCheck, { size: 22 })
-        })
-      })"
-    />
+    <RingProgress :sections="[{ value: 100, color: 'teal' }]">
+      <template #label>
+        <Center>
+          <ActionIcon color="teal" variant="light" radius="xl" size="xl">
+            <PhCheck :size="22" />
+          </ActionIcon>
+        </Center>
+      </template>
+    </RingProgress>
   </Group>
 </template>
 `

--- a/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.transitions.ts
+++ b/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.transitions.ts
@@ -12,6 +12,12 @@ const value = ref(30)
 
 <template>
   <Stack align="center">
+    <RingProgress :sections="[{ value, color: 'blue' }]" :transitionDuration="250">
+      <template #label>
+        <Text ta="center">{{ value }}%</Text>
+      </template>
+    </RingProgress>
+
     <RingProgress
       :sections="[{ value, color: 'blue' }]"
       :transitionDuration="250"

--- a/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.usage.ts
+++ b/apps/mantine.dev/src/demos/core/RingProgress/RingProgress.demo.usage.ts
@@ -9,6 +9,18 @@ import { RingProgress, Text } from '@mantine-vue/core'
 
 <template>
   <RingProgress
+    :sections="[
+      { value: 40, color: 'cyan' },
+      { value: 15, color: 'orange' },
+      { value: 15, color: 'grape' },
+    ]"
+  >
+    <template #label>
+      <Text size="xs" ta="center">Application data usage</Text>
+    </template>
+  </RingProgress>
+
+  <RingProgress
     :label="h(Text, { size: 'xs', ta: 'center' }, { default: () => 'Application data usage' })"
     :sections="[
       { value: 40, color: 'cyan' },

--- a/apps/mantine.dev/src/demos/core/Scroller/Scroller.demo.customIcons.ts
+++ b/apps/mantine.dev/src/demos/core/Scroller/Scroller.demo.customIcons.ts
@@ -10,7 +10,14 @@ import { Badge, Group, Scroller } from '@mantine-vue/core'
 </script>
 
 <template>
-  <Scroller :startControlIcon="() => h(PhArrowLeft, { size: 16 })" :endControlIcon="() => h(PhArrowRight, { size: 16 })">
+  <Scroller>
+    <template #startControlIcon>
+      <PhArrowLeft :size="16" />
+    </template>
+    <template #endControlIcon>
+      <PhArrowRight :size="16" />
+    </template>
+
     <Group gap="xs" wrap="nowrap">
       <Badge
         v-for="index in 20"

--- a/apps/mantine.dev/src/demos/core/Stepper/Stepper.demo.icons.ts
+++ b/apps/mantine.dev/src/demos/core/Stepper/Stepper.demo.icons.ts
@@ -13,26 +13,26 @@ const active = ref(1)
 </script>
 
 <template>
-  <Stepper
-    :active="active"
-    @step-click="active = $event"
-    :completed-icon="() => h(PhCheckCircle, { size: 18 })"
-  >
-    <Stepper.Step
-      :icon="() => h(PhUserCheck, { size: 18 })"
-      label="Step 1"
-      description="Create an account"
-    />
-    <Stepper.Step
-      :icon="() => h(PhEnvelopeOpen, { size: 18 })"
-      label="Step 2"
-      description="Verify email"
-    />
-    <Stepper.Step
-      :icon="() => h(PhShieldCheck, { size: 18 })"
-      label="Step 3"
-      description="Get full access"
-    />
+  <Stepper :active="active" @step-click="active = $event">
+    <template #completedIcon>
+      <PhCheckCircle :size="18" />
+    </template>
+
+    <Stepper.Step label="Step 1" description="Create an account">
+      <template #icon>
+        <PhUserCheck :size="18" />
+      </template>
+    </Stepper.Step>
+    <Stepper.Step label="Step 2" description="Verify email">
+      <template #icon>
+        <PhEnvelopeOpen :size="18" />
+      </template>
+    </Stepper.Step>
+    <Stepper.Step label="Step 3" description="Get full access">
+      <template #icon>
+        <PhShieldCheck :size="18" />
+      </template>
+    </Stepper.Step>
   </Stepper>
 </template>
 `

--- a/apps/mantine.dev/src/demos/core/Stepper/Stepper.demo.iconsOnly.ts
+++ b/apps/mantine.dev/src/demos/core/Stepper/Stepper.demo.iconsOnly.ts
@@ -14,9 +14,15 @@ const active = ref(0)
 
 <template>
   <Stepper :active="active" @step-click="active = $event">
-    <Stepper.Step :icon="() => h(PhUserCheck, { size: 18 })" />
-    <Stepper.Step :icon="() => h(PhEnvelopeOpen, { size: 18 })" />
-    <Stepper.Step :icon="() => h(PhShieldCheck, { size: 18 })" />
+    <Stepper.Step>
+      <template #icon><PhUserCheck :size="18" /></template>
+    </Stepper.Step>
+    <Stepper.Step>
+      <template #icon><PhEnvelopeOpen :size="18" /></template>
+    </Stepper.Step>
+    <Stepper.Step>
+      <template #icon><PhShieldCheck :size="18" /></template>
+    </Stepper.Step>
   </Stepper>
 </template>
 `

--- a/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
+++ b/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
@@ -19,8 +19,11 @@ const value = ref('')
     :min-rows="4"
     :value="value"
     @change="(event) => (value = event.currentTarget.value.slice(0, maxLength))"
-    :bottom-section="h(Text, { size: 'xs', c: 'dimmed' }, () => \`\${value.length}/\${maxLength} characters\`)"
-  />
+  >
+    <template #bottomSection>
+      <Text size="xs" c="dimmed">{{ value.length }}/{{ maxLength }} characters</Text>
+    </template>
+  </Textarea>
 </template>
 `
 

--- a/apps/mantine.dev/src/demos/core/Timeline/Timeline.demo.bullet.ts
+++ b/apps/mantine.dev/src/demos/core/Timeline/Timeline.demo.bullet.ts
@@ -15,21 +15,30 @@ import { PhSun, PhVideoCamera } from '@phosphor-icons/vue'
       <Text c="dimmed" size="sm">Default bullet without anything</Text>
     </Timeline.Item>
 
-    <Timeline.Item
-      title="Avatar"
-      :bullet="h(Avatar, { size: 22, radius: 'xl', src: 'https://avatars0.githubusercontent.com/u/10353856?s=460&u=88394dfd67727327c1f7670a1764dc38a8a24831&v=4' })"
-    >
+    <Timeline.Item title="Avatar">
+      <template #bullet>
+        <Avatar
+          :size="22"
+          radius="xl"
+          src="https://avatars0.githubusercontent.com/u/10353856?s=460&u=88394dfd67727327c1f7670a1764dc38a8a24831&v=4"
+        />
+      </template>
       <Text c="dimmed" size="sm">Timeline bullet as avatar image</Text>
     </Timeline.Item>
 
-    <Timeline.Item title="Icon" :bullet="h(PhSun, { size: 13 })">
+    <Timeline.Item title="Icon">
+      <template #bullet>
+        <PhSun :size="13" />
+      </template>
       <Text c="dimmed" size="sm">Timeline bullet as icon</Text>
     </Timeline.Item>
 
-    <Timeline.Item
-      title="ThemeIcon"
-      :bullet="h(ThemeIcon, { size: 22, variant: 'gradient', gradient: { from: 'lime', to: 'cyan' }, radius: 'xl' }, { default: () => h(PhVideoCamera, { size: 13 }) })"
-    >
+    <Timeline.Item title="ThemeIcon">
+      <template #bullet>
+        <ThemeIcon :size="22" variant="gradient" :gradient="{ from: 'lime', to: 'cyan' }" radius="xl">
+          <PhVideoCamera :size="13" />
+        </ThemeIcon>
+      </template>
       <Text c="dimmed" size="sm">Timeline bullet as ThemeIcon component</Text>
     </Timeline.Item>
   </Timeline>

--- a/apps/mantine.dev/src/demos/core/Timeline/Timeline.demo.usage.ts
+++ b/apps/mantine.dev/src/demos/core/Timeline/Timeline.demo.usage.ts
@@ -11,7 +11,10 @@ import { PhGitBranch, PhGitCommit, PhGitPullRequest, PhChatCircleDots } from '@p
 
 <template>
   <Timeline :active="1" :bulletSize="24" :lineWidth="2">
-    <Timeline.Item :bullet="h(PhGitBranch, { size: 12 })" title="New branch">
+    <Timeline.Item title="New branch">
+      <template #bullet>
+        <PhGitBranch :size="12" />
+      </template>
       <Text c="dimmed" size="sm">
         You've created new branch
         <Text c="blue" component="span" inherit>fix-notifications</Text>
@@ -20,7 +23,10 @@ import { PhGitBranch, PhGitCommit, PhGitPullRequest, PhChatCircleDots } from '@p
       <Text size="xs" :mt="4">2 hours ago</Text>
     </Timeline.Item>
 
-    <Timeline.Item :bullet="h(PhGitCommit, { size: 12 })" title="Commits">
+    <Timeline.Item title="Commits">
+      <template #bullet>
+        <PhGitCommit :size="12" />
+      </template>
       <Text c="dimmed" size="sm">
         You've pushed 23 commits to
         <Text c="blue" component="span" inherit>fix-notifications</Text>
@@ -29,7 +35,10 @@ import { PhGitBranch, PhGitCommit, PhGitPullRequest, PhChatCircleDots } from '@p
       <Text size="xs" :mt="4">52 minutes ago</Text>
     </Timeline.Item>
 
-    <Timeline.Item title="Pull request" :bullet="h(PhGitPullRequest, { size: 12 })" lineVariant="dashed">
+    <Timeline.Item title="Pull request" lineVariant="dashed">
+      <template #bullet>
+        <PhGitPullRequest :size="12" />
+      </template>
       <Text c="dimmed" size="sm">
         You've submitted a pull request
         <Text c="blue" component="span" inherit>Fix incorrect notification message (#187)</Text>
@@ -37,7 +46,10 @@ import { PhGitBranch, PhGitCommit, PhGitPullRequest, PhChatCircleDots } from '@p
       <Text size="xs" :mt="4">34 minutes ago</Text>
     </Timeline.Item>
 
-    <Timeline.Item title="Code review" :bullet="h(PhChatCircleDots, { size: 12 })">
+    <Timeline.Item title="Code review">
+      <template #bullet>
+        <PhChatCircleDots :size="12" />
+      </template>
       <Text c="dimmed" size="sm">
         <Text c="blue" component="span" inherit>Robert Gluesticker</Text>
         left a code review on your pull request

--- a/apps/mantine.dev/src/pages/core/accordion.mdx
+++ b/apps/mantine.dev/src/pages/core/accordion.mdx
@@ -17,6 +17,8 @@ to fit correctly within the outline of the page.
 ## Change chevron
 
 Use the `chevron` prop to change the chevron icon. To remove it, set `:chevron="null"`.
+You can also provide this content through the `#chevron` named slot on `Accordion`, which
+applies to every `Accordion.Control`, or on an individual `Accordion.Control`.
 
 To customize chevron styles, use the Styles API with the `data-rotate` attribute
 (set when the item is open, unless `disableChevronRotation` is set):
@@ -32,7 +34,8 @@ set `aria-label` to keep the control accessible for screen readers.
 
 ## With icons
 
-Use the `icon` prop to display any element in the left section of `Accordion.Control`:
+Use the `icon` prop to display any element in the left section of `Accordion.Control`.
+You can also provide this content through the `#icon` named slot:
 
 <Demo data={AccordionDemos.icons} />
 

--- a/apps/mantine.dev/src/pages/core/color-input.mdx
+++ b/apps/mantine.dev/src/pages/core/color-input.mdx
@@ -95,7 +95,8 @@ To disable it, set `:withEyeDropper="false"`:
 
 ## Change eye dropper icon
 
-You can replace the eye dropper icon with any node using the `eyeDropperIcon` prop:
+You can replace the eye dropper icon with any node using the `eyeDropperIcon` prop.
+You can also provide this content through the `#eyeDropperIcon` named slot:
 
 <Demo data={ColorInputDemos.eyeDropperIcon} />
 

--- a/apps/mantine.dev/src/pages/core/password-input.mdx
+++ b/apps/mantine.dev/src/pages/core/password-input.mdx
@@ -66,7 +66,20 @@ For example, the props can be used to sync visibility state between two inputs:
 
 ## Change visibility toggle icon
 
-To change the visibility toggle icon, pass a Vue component that accepts the `reveal` prop to `visibilityToggleIcon`:
+To change the visibility toggle icon, pass a Vue component that accepts the `reveal` prop to `visibilityToggleIcon`.
+You can also provide this content through the `#visibilityToggleIcon` named slot, which receives
+the same `{ reveal }` payload:
+
+```vue
+<template>
+  <PasswordInput label="Password">
+    <template #visibilityToggleIcon="{ reveal }">
+      <PhEyeSlash v-if="reveal" :size="18" />
+      <PhEye v-else :size="18" />
+    </template>
+  </PasswordInput>
+</template>
+```
 
 <Demo data={PasswordInputDemos.visibilityIcon} />
 

--- a/apps/mantine.dev/src/pages/core/scroller.mdx
+++ b/apps/mantine.dev/src/pages/core/scroller.mdx
@@ -35,6 +35,7 @@ Mantine size value (`xs`, `sm`, `md`, `lg`, `xl`) or a number (converted to pixe
 ## Custom icons
 
 Use `startControlIcon` and `endControlIcon` props to replace default chevron icons
-with custom icons:
+with custom icons. You can also provide this content through the `#startControlIcon`
+and `#endControlIcon` named slots:
 
 <Demo data={ScrollerDemos.customIcons} />

--- a/apps/mantine.dev/src/pages/core/splitter.mdx
+++ b/apps/mantine.dev/src/pages/core/splitter.mdx
@@ -56,6 +56,24 @@ Use `lineSize` prop to control the thickness of the separator line between panes
 
 <Demo data={SplitterDemos.lineSize} />
 
+## Custom handle icon
+
+Use the `handleIcon` prop to replace the default grip icon rendered inside every handle.
+You can also provide this content through the `#handleIcon` named slot:
+
+```vue
+<template>
+  <Splitter withHandle>
+    <template #handleIcon>
+      <PhDotsSixVertical :size="14" />
+    </template>
+
+    <Splitter.Pane :defaultSize="50">First</Splitter.Pane>
+    <Splitter.Pane :defaultSize="50">Second</Splitter.Pane>
+  </Splitter>
+</template>
+```
+
 ## Without handle
 
 Set `:withHandle="false"` to hide the thumb with grip icon. The separator line

--- a/apps/mantine.dev/src/pages/core/stepper.mdx
+++ b/apps/mantine.dev/src/pages/core/stepper.mdx
@@ -35,7 +35,11 @@ The `size` prop controls icon size, label and description font size.
 
 Replace the step icon by setting the `icon` prop on `Stepper.Step`.
 To change the completed check icon, set `completedIcon` on the `Stepper` component.
-Pass a render function `() => h(Icon, props)` as the icon value:
+Pass a render function `() => h(Icon, props)` as the icon value.
+
+The `#icon`, `#completedIcon` and `#progressIcon` named slots are supported as an alternative,
+both on `Stepper` (applies to every step) and on an individual `Stepper.Step` (takes precedence
+over the `Stepper` level value):
 
 <Demo data={StepperDemos.icons} />
 

--- a/apps/mantine.dev/src/pages/core/textarea.mdx
+++ b/apps/mantine.dev/src/pages/core/textarea.mdx
@@ -60,6 +60,7 @@ function handleSubmit(event: Event) {
 ## Bottom section
 
 Use `bottomSection` prop to render content inside the input border at the bottom.
+You can also provide this content through the `#bottomSection` named slot.
 This is useful for displaying character counters, hints, or other supplementary information:
 
 <Demo data={TextareaDemos.bottomSection} />

--- a/packages/@mantine-vue/core/src/components/Accordion/Accordion.ts
+++ b/packages/@mantine-vue/core/src/components/Accordion/Accordion.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, reactive, type PropType } from 'vue'
+import { defineComponent, h, reactive, type PropType, type SlotsType, type VNodeChild } from 'vue'
 import { useId, useUncontrolled } from '@mantine-vue/hooks'
 import {
   Box,
@@ -33,6 +33,12 @@ export type AccordionStylesNames =
   | 'control'
 
 export type AccordionVariant = 'default' | 'contained' | 'filled' | 'separated'
+
+export interface AccordionSlots {
+  default?: () => VNodeChild
+  /** Custom chevron used by all Accordion.Control components, alternative to the `chevron` prop */
+  chevron?: () => VNodeChild
+}
 
 const VALUE_ERROR = 'Accordion.Item component was rendered with invalid value or without value'
 
@@ -72,6 +78,7 @@ const varsResolver = createVarsResolver<any>((_, { transitionDuration, chevronSi
 const AccordionBase = defineComponent({
   name: 'Accordion',
   inheritAttrs: false,
+  slots: Object as SlotsType<AccordionSlots>,
   props: {
     multiple: { type: Boolean, default: undefined },
     value: { type: [String, Array] as PropType<string | string[] | null>, default: undefined },
@@ -161,9 +168,15 @@ const AccordionBase = defineComponent({
           return props.order
         },
         get chevron() {
-          return props.chevron === null
-            ? null
-            : (props.chevron ?? (() => h(AccordionChevron, { size: props.chevronIconSize })))
+          if (props.chevron === null) {
+            return null
+          }
+
+          return (
+            props.chevron ??
+            slots.chevron ??
+            (() => h(AccordionChevron, { size: props.chevronIconSize }))
+          )
         },
         onChange: handleItemChange,
         isItemActive,

--- a/packages/@mantine-vue/core/src/components/Accordion/index.ts
+++ b/packages/@mantine-vue/core/src/components/Accordion/index.ts
@@ -1,5 +1,5 @@
 export { Accordion } from './Accordion'
-export type { AccordionStylesNames, AccordionVariant } from './Accordion'
+export type { AccordionSlots, AccordionStylesNames, AccordionVariant } from './Accordion'
 export { AccordionChevron } from './AccordionChevron'
 export { AccordionControl } from './AccordionControl/AccordionControl'
 export type { AccordionControlStylesNames } from './AccordionControl/AccordionControl'

--- a/packages/@mantine-vue/core/src/components/ColorInput/ColorInput.ts
+++ b/packages/@mantine-vue/core/src/components/ColorInput/ColorInput.ts
@@ -1,4 +1,14 @@
-import { computed, defineComponent, h, ref, watch, type PropType } from 'vue'
+import {
+  computed,
+  defineComponent,
+  h,
+  ref,
+  watch,
+  type PropType,
+  type SlotsType,
+  type VNodeChild,
+} from 'vue'
+import { resolveNode } from '../../core'
 import {
   ColorPicker,
   convertHsvaTo,
@@ -8,7 +18,7 @@ import {
 } from '../ColorPicker'
 import { ActionIcon } from '../ActionIcon'
 import { ColorSwatch } from '../ColorSwatch'
-import { InputBase } from '../InputBase'
+import { InputBase, type InputBaseSlots } from '../InputBase'
 import { Popover } from '../Popover'
 import { EyeDropperIcon } from './EyeDropperIcon'
 import classes from './ColorInput.module.css'
@@ -31,9 +41,15 @@ export interface ColorInputProps {
   [key: string]: any
 }
 
+export interface ColorInputSlots extends InputBaseSlots {
+  /** Custom eye dropper button icon, alternative to the `eyeDropperIcon` prop */
+  eyeDropperIcon?: () => VNodeChild
+}
+
 export const ColorInput = defineComponent({
   name: 'ColorInput',
   inheritAttrs: false,
+  slots: Object as SlotsType<ColorInputSlots>,
   props: {
     modelValue: String,
     value: String,
@@ -117,7 +133,7 @@ export const ColorInput = defineComponent({
                 onClick: useEyeDropper,
               },
               () =>
-                props.eyeDropperIcon ??
+                resolveNode(props.eyeDropperIcon, slots.eyeDropperIcon) ??
                 h(EyeDropperIcon, {
                   class: classes.eyeDropperIcon,
                 }),

--- a/packages/@mantine-vue/core/src/components/ColorInput/index.ts
+++ b/packages/@mantine-vue/core/src/components/ColorInput/index.ts
@@ -1,2 +1,2 @@
 export { ColorInput } from './ColorInput'
-export type { ColorInputProps } from './ColorInput'
+export type { ColorInputProps, ColorInputSlots } from './ColorInput'

--- a/packages/@mantine-vue/core/src/components/InputBase/index.ts
+++ b/packages/@mantine-vue/core/src/components/InputBase/index.ts
@@ -1,2 +1,2 @@
 export { InputBase } from './InputBase'
-export type { InputBaseStylesNames } from './InputBase'
+export type { InputBaseSlots, InputBaseStylesNames } from './InputBase'

--- a/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
+++ b/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
@@ -20,6 +20,8 @@ export interface PasswordInputSlots {
   error?: () => VNodeChild
   leftSection?: () => VNodeChild
   rightSection?: () => VNodeChild
+  /** Custom visibility toggle icon, alternative to the `visibilityToggleIcon` prop */
+  visibilityToggleIcon?: (payload: { reveal: boolean }) => VNodeChild
 }
 
 export type PasswordInputStylesNames =
@@ -138,7 +140,17 @@ export const PasswordInput = defineComponent({
         props.description !== undefined ? props.description !== null : Boolean(slots.description)
       const describedBy =
         `${hasError ? errorId : ''} ${hasDescription ? descriptionId : ''}`.trim() || undefined
-      const VisibilityToggleIcon = props.visibilityToggleIcon || PasswordToggleIcon
+      const renderVisibilityToggleIcon = () => {
+        if (props.visibilityToggleIcon) {
+          return h(props.visibilityToggleIcon, { reveal: visible.value })
+        }
+
+        if (slots.visibilityToggleIcon) {
+          return slots.visibilityToggleIcon({ reveal: visible.value })
+        }
+
+        return h(PasswordToggleIcon, { reveal: visible.value })
+      }
       const visibilityToggleButton = h(
         ActionIcon,
         {
@@ -171,7 +183,7 @@ export const PasswordInput = defineComponent({
             }
           },
         },
-        () => h(VisibilityToggleIcon, { reveal: visible.value }),
+        renderVisibilityToggleIcon,
       )
 
       return h(

--- a/packages/@mantine-vue/core/src/components/PasswordInput/index.ts
+++ b/packages/@mantine-vue/core/src/components/PasswordInput/index.ts
@@ -1,3 +1,3 @@
 export { PasswordInput } from './PasswordInput'
-export type { PasswordInputStylesNames } from './PasswordInput'
+export type { PasswordInputSlots, PasswordInputStylesNames } from './PasswordInput'
 export { PasswordToggleIcon } from './PasswordToggleIcon'

--- a/packages/@mantine-vue/core/src/components/Scroller/Scroller.ts
+++ b/packages/@mantine-vue/core/src/components/Scroller/Scroller.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, type PropType } from 'vue'
+import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
 import { useScroller } from '@mantine-vue/hooks'
 import {
   withBoxProps,
@@ -6,6 +6,7 @@ import {
   createVarsResolver,
   getThemeColor,
   rem,
+  resolveNode,
   useProps,
   useStyles,
 } from '../../core'
@@ -37,6 +38,14 @@ export interface ScrollerProps {
   unstyled?: boolean
 }
 
+export interface ScrollerSlots {
+  default?: () => VNodeChild
+  /** Custom start control icon, alternative to the `startControlIcon` prop */
+  startControlIcon?: () => VNodeChild
+  /** Custom end control icon, alternative to the `endControlIcon` prop */
+  endControlIcon?: () => VNodeChild
+}
+
 const defaultProps = {
   scrollAmount: 200,
   draggable: true,
@@ -51,14 +60,11 @@ const varsResolver = createVarsResolver<any>((theme, { controlSize, edgeGradient
   },
 }))
 
-function renderContent(content: any) {
-  return typeof content === 'function' ? content() : content
-}
-
 export const Scroller = withBoxProps(
   defineComponent({
     name: 'Scroller',
     inheritAttrs: false,
+    slots: Object as SlotsType<ScrollerSlots>,
     props: {
       scrollAmount: { type: Number, default: undefined },
       controlSize: { type: [String, Number] as PropType<string | number>, default: undefined },
@@ -120,7 +126,8 @@ export const Scroller = withBoxProps(
                 tabindex: showStart ? 0 : -1,
               },
               () =>
-                renderContent(props.startControlIcon) || h(AccordionChevron, getStyles('chevron')),
+                resolveNode(props.startControlIcon, slots.startControlIcon) ||
+                h(AccordionChevron, getStyles('chevron')),
             ),
             h(
               'div',
@@ -131,7 +138,7 @@ export const Scroller = withBoxProps(
                 'data-draggable': props.draggable || undefined,
                 ...scroller.dragHandlers,
               },
-              h('div', getStyles('content'), slots.default?.()),
+              h('div', getStyles('content'), slots.default?.() as any),
             ),
             h(
               UnstyledButton,
@@ -145,7 +152,8 @@ export const Scroller = withBoxProps(
                 tabindex: showEnd ? 0 : -1,
               },
               () =>
-                renderContent(props.endControlIcon) || h(AccordionChevron, getStyles('chevron')),
+                resolveNode(props.endControlIcon, slots.endControlIcon) ||
+                h(AccordionChevron, getStyles('chevron')),
             ),
           ],
         )

--- a/packages/@mantine-vue/core/src/components/Scroller/index.ts
+++ b/packages/@mantine-vue/core/src/components/Scroller/index.ts
@@ -1,2 +1,7 @@
 export { Scroller } from './Scroller'
-export type { ScrollerCssVariables, ScrollerProps, ScrollerStylesNames } from './Scroller'
+export type {
+  ScrollerCssVariables,
+  ScrollerProps,
+  ScrollerSlots,
+  ScrollerStylesNames,
+} from './Scroller'

--- a/packages/@mantine-vue/core/src/components/Splitter/Splitter.ts
+++ b/packages/@mantine-vue/core/src/components/Splitter/Splitter.ts
@@ -5,6 +5,7 @@ import {
   h,
   shallowRef,
   type PropType,
+  type SlotsType,
   type VNode,
   type VNodeChild,
 } from 'vue'
@@ -15,6 +16,7 @@ import {
   Box,
   createVarsResolver,
   getThemeColor,
+  resolveNode,
   useDirection,
   useProps,
   useStyles,
@@ -55,6 +57,12 @@ export interface SplitterProps {
   unstyled?: boolean
 }
 
+export interface SplitterSlots {
+  default?: () => VNodeChild
+  /** Custom icon rendered inside every resize handle, alternative to the `handleIcon` prop */
+  handleIcon?: () => VNodeChild
+}
+
 const defaultProps = {
   orientation: 'horizontal',
   lineSize: 2,
@@ -82,6 +90,7 @@ function flattenChildren(children: VNode[]): VNode[] {
 const SplitterBase = defineComponent({
   name: 'Splitter',
   inheritAttrs: false,
+  slots: Object as SlotsType<SplitterSlots>,
   props: {
     orientation: { type: String as PropType<'horizontal' | 'vertical'>, default: undefined },
     sizes: { type: Array as PropType<number[]>, default: undefined },
@@ -199,8 +208,8 @@ const SplitterBase = defineComponent({
                         'data-active': splitter.activeHandle === handleIndex || undefined,
                       },
                       [
-                        props.handleIcon !== undefined
-                          ? props.handleIcon
+                        props.handleIcon !== undefined || slots.handleIcon
+                          ? resolveNode(props.handleIcon, slots.handleIcon)
                           : h(
                               props.orientation === 'vertical'
                                 ? GripHorizontalIcon

--- a/packages/@mantine-vue/core/src/components/Splitter/index.ts
+++ b/packages/@mantine-vue/core/src/components/Splitter/index.ts
@@ -1,5 +1,10 @@
 export { Splitter } from './Splitter'
-export type { SplitterProps, SplitterStylesNames, SplitterCssVariables } from './Splitter'
+export type {
+  SplitterProps,
+  SplitterSlots,
+  SplitterStylesNames,
+  SplitterCssVariables,
+} from './Splitter'
 export { SplitterPane } from './SplitterPane/SplitterPane'
 export type { SplitterPaneProps, SplitterPaneStylesNames } from './SplitterPane/SplitterPane'
 export { useSplitterContext } from './Splitter.context'

--- a/packages/@mantine-vue/core/src/components/Stepper/Stepper.ts
+++ b/packages/@mantine-vue/core/src/components/Stepper/Stepper.ts
@@ -29,7 +29,7 @@ import {
 } from '../../core'
 import { provideStepperContext } from './Stepper.context'
 import { StepperCompleted } from './StepperCompleted/StepperCompleted'
-import { StepperStep } from './StepperStep/StepperStep'
+import { StepperStep, type StepperStepSlots } from './StepperStep/StepperStep'
 import classes from './Stepper.module.css'
 
 export interface StepperSlots {
@@ -157,6 +157,9 @@ const StepperBase = defineComponent({
 
       steps.forEach((item, index) => {
         const itemProps = (item.props ?? {}) as Record<string, any>
+        // Slots declared on Stepper.Step itself. They must win over the fragments inherited from
+        // Stepper, otherwise the injected props below would always shadow them.
+        const itemSlots = (item.children ?? {}) as unknown as Partial<StepperStepSlots>
         const state =
           props.active === index
             ? 'stepProgress'
@@ -173,26 +176,29 @@ const StepperBase = defineComponent({
           cloneVNode(
             item,
             {
-              icon:
-                itemProps.icon ??
-                props.icon ??
-                (slots.icon ? (payload: { step: number }) => slots.icon!(payload) : index + 1),
+              icon: itemSlots.icon
+                ? itemProps.icon
+                : (itemProps.icon ??
+                  props.icon ??
+                  (slots.icon ? (payload: { step: number }) => slots.icon!(payload) : index + 1)),
               step: index,
               state,
               onClick: () => selectable && props.onStepClick?.(index),
               allowStepClick: selectable,
-              completedIcon:
-                itemProps.completedIcon ??
-                props.completedIcon ??
-                (slots.completedIcon
-                  ? (payload: { step: number }) => slots.completedIcon!(payload)
-                  : undefined),
-              progressIcon:
-                itemProps.progressIcon ??
-                props.progressIcon ??
-                (slots.progressIcon
-                  ? (payload: { step: number }) => slots.progressIcon!(payload)
-                  : undefined),
+              completedIcon: itemSlots.completedIcon
+                ? itemProps.completedIcon
+                : (itemProps.completedIcon ??
+                  props.completedIcon ??
+                  (slots.completedIcon
+                    ? (payload: { step: number }) => slots.completedIcon!(payload)
+                    : undefined)),
+              progressIcon: itemSlots.progressIcon
+                ? itemProps.progressIcon
+                : (itemProps.progressIcon ??
+                  props.progressIcon ??
+                  (slots.progressIcon
+                    ? (payload: { step: number }) => slots.progressIcon!(payload)
+                    : undefined)),
               color: itemProps.color ?? props.color,
               iconSize: props.iconSize,
               iconPosition: itemProps.iconPosition ?? props.iconPosition,

--- a/packages/@mantine-vue/core/src/components/Textarea/Textarea.ts
+++ b/packages/@mantine-vue/core/src/components/Textarea/Textarea.ts
@@ -1,10 +1,17 @@
-import { defineComponent, h, type PropType } from 'vue'
-import { InputBase } from '../InputBase'
+import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
+import { resolveNode } from '../../core'
+import { InputBase, type InputBaseSlots } from '../InputBase'
 import { TextareaAutosize } from './Autosize'
+
+export interface TextareaSlots extends InputBaseSlots {
+  /** Content rendered below the textarea, alternative to the `bottomSection` prop */
+  bottomSection?: () => VNodeChild
+}
 
 export const Textarea = defineComponent({
   name: 'Textarea',
   inheritAttrs: false,
+  slots: Object as SlotsType<TextareaSlots>,
   props: {
     autosize: { type: Boolean, default: false },
     maxRows: { type: Number, default: undefined },
@@ -36,7 +43,7 @@ export const Textarea = defineComponent({
           multiline: true,
           // data-no-overflow suppresses overflow scrollbar when no maxRows cap
           'data-no-overflow': shouldAutosize && props.maxRows === undefined ? true : undefined,
-          __bottomSection: props.bottomSection,
+          __bottomSection: resolveNode(props.bottomSection, slots.bottomSection),
           __bottomSectionProps: props.bottomSectionProps,
           style: [{ '--input-resize': props.resize }, (attrs as any).style],
           ...autosizeProps,

--- a/packages/@mantine-vue/core/src/components/Textarea/index.ts
+++ b/packages/@mantine-vue/core/src/components/Textarea/index.ts
@@ -1,1 +1,2 @@
 export { Textarea } from './Textarea'
+export type { TextareaSlots } from './Textarea'

--- a/packages/@mantine-vue/core/src/components/__tests__/named-slots.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/named-slots.test.ts
@@ -2,15 +2,27 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 import { mount } from '@vue/test-utils'
 import {
+  Accordion,
+  AccordionControl,
+  AccordionItem,
+  AccordionPanel,
   Alert,
   Button,
   Checkbox,
+  ColorInput,
   ComboboxPopover,
   Divider,
   EmptyState,
   MantineProvider,
+  PasswordInput,
   Radio,
+  Scroller,
+  Splitter,
+  SplitterPane,
+  Stepper,
+  StepperStep,
   TextInput,
+  Textarea,
   Timeline,
   TimelineItem,
 } from '../../index'
@@ -228,5 +240,216 @@ describe('@mantine-vue/core named slots', () => {
     )
     expect(both.text()).toContain('Prop message')
     expect(both.find('.slot-nf').exists()).toBe(false)
+  })
+
+  it('Accordion: #chevron slot is used by every control, chevron prop wins', () => {
+    const accordionItems = () => [
+      h(AccordionItem, { value: 'item-1' }, () => [
+        h(AccordionControl, null, () => 'Label 1'),
+        h(AccordionPanel, null, () => 'Panel 1'),
+      ]),
+      h(AccordionItem, { value: 'item-2' }, () => [
+        h(AccordionControl, null, () => 'Label 2'),
+        h(AccordionPanel, null, () => 'Panel 2'),
+      ]),
+    ]
+
+    const fromSlot = withProvider(
+      Accordion,
+      { transitionDuration: 0 },
+      { default: accordionItems, chevron: () => h('span', { class: 'slot-chevron' }, '+') },
+    )
+    expect(fromSlot.findAll('.slot-chevron')).toHaveLength(2)
+
+    const both = withProvider(
+      Accordion,
+      { transitionDuration: 0, chevron: h('span', { class: 'prop-chevron' }, '-') },
+      { default: accordionItems, chevron: () => h('span', { class: 'slot-chevron' }, '+') },
+    )
+    expect(both.findAll('.prop-chevron')).toHaveLength(2)
+    expect(both.find('.slot-chevron').exists()).toBe(false)
+  })
+
+  it('Accordion: chevron={null} still renders no chevron content', () => {
+    const wrapper = withProvider(
+      Accordion,
+      { transitionDuration: 0, chevron: null },
+      {
+        default: () => [
+          h(AccordionItem, { value: 'item-1' }, () => [
+            h(AccordionControl, null, () => 'Label 1'),
+            h(AccordionPanel, null, () => 'Panel 1'),
+          ]),
+        ],
+      },
+    )
+    expect(wrapper.find('.mantine-Accordion-chevron svg').exists()).toBe(false)
+  })
+
+  it('ColorInput: renders #eyeDropperIcon slot, eyeDropperIcon prop wins', () => {
+    ;(window as any).EyeDropper = class {}
+
+    const fromSlot = withProvider(
+      ColorInput,
+      {},
+      { eyeDropperIcon: () => h('span', { class: 'slot-eye' }, 'E') },
+    )
+    expect(fromSlot.find('.slot-eye').exists()).toBe(true)
+
+    const both = withProvider(
+      ColorInput,
+      { eyeDropperIcon: h('span', { class: 'prop-eye' }, 'E') },
+      { eyeDropperIcon: () => h('span', { class: 'slot-eye' }, 'E') },
+    )
+    expect(both.find('.prop-eye').exists()).toBe(true)
+    expect(both.find('.slot-eye').exists()).toBe(false)
+
+    delete (window as any).EyeDropper
+  })
+
+  it('Scroller: renders #startControlIcon and #endControlIcon slots, props win', () => {
+    const fromSlots = withProvider(
+      Scroller,
+      {},
+      {
+        default: () => h('div', 'content'),
+        startControlIcon: () => h('span', { class: 'slot-start' }, '<'),
+        endControlIcon: () => h('span', { class: 'slot-end' }, '>'),
+      },
+    )
+    expect(fromSlots.find('.slot-start').exists()).toBe(true)
+    expect(fromSlots.find('.slot-end').exists()).toBe(true)
+
+    const both = withProvider(
+      Scroller,
+      { startControlIcon: h('span', { class: 'prop-start' }, '<') },
+      {
+        default: () => h('div', 'content'),
+        startControlIcon: () => h('span', { class: 'slot-start' }, '<'),
+      },
+    )
+    expect(both.find('.prop-start').exists()).toBe(true)
+    expect(both.find('.slot-start').exists()).toBe(false)
+  })
+
+  it('Splitter: renders #handleIcon slot in the handle, handleIcon prop wins', () => {
+    const panes = () => [
+      h(SplitterPane, { defaultSize: 50 }, () => 'left'),
+      h(SplitterPane, { defaultSize: 50 }, () => 'right'),
+    ]
+
+    const fromSlot = withProvider(
+      Splitter,
+      { withHandle: true },
+      { default: panes, handleIcon: () => h('span', { class: 'slot-handle' }, '::') },
+    )
+    expect(fromSlot.find('.slot-handle').exists()).toBe(true)
+
+    const both = withProvider(
+      Splitter,
+      { withHandle: true, handleIcon: h('span', { class: 'prop-handle' }, '::') },
+      { default: panes, handleIcon: () => h('span', { class: 'slot-handle' }, '::') },
+    )
+    expect(both.find('.prop-handle').exists()).toBe(true)
+    expect(both.find('.slot-handle').exists()).toBe(false)
+  })
+
+  it('Textarea: renders #bottomSection slot, bottomSection prop wins', () => {
+    const fromSlot = withProvider(
+      Textarea,
+      {},
+      { bottomSection: () => h('span', { class: 'slot-bottom' }, '0/100') },
+    )
+    expect(fromSlot.find('.slot-bottom').exists()).toBe(true)
+
+    const both = withProvider(
+      Textarea,
+      { bottomSection: h('span', { class: 'prop-bottom' }, '0/100') },
+      { bottomSection: () => h('span', { class: 'slot-bottom' }, '0/100') },
+    )
+    expect(both.find('.prop-bottom').exists()).toBe(true)
+    expect(both.find('.slot-bottom').exists()).toBe(false)
+  })
+
+  it('PasswordInput: #visibilityToggleIcon slot receives the reveal payload', async () => {
+    const wrapper = withProvider(
+      PasswordInput,
+      {},
+      {
+        visibilityToggleIcon: ({ reveal }: { reveal: boolean }) =>
+          h('span', { class: 'slot-toggle' }, reveal ? 'visible' : 'hidden'),
+      },
+    )
+    expect(wrapper.find('.slot-toggle').text()).toBe('hidden')
+
+    await wrapper.find('button').trigger('mousedown')
+    expect(wrapper.find('.slot-toggle').text()).toBe('visible')
+  })
+
+  it('PasswordInput: visibilityToggleIcon prop wins over the slot', () => {
+    const wrapper = withProvider(
+      PasswordInput,
+      { visibilityToggleIcon: { render: () => h('span', { class: 'prop-toggle' }) } },
+      { visibilityToggleIcon: () => h('span', { class: 'slot-toggle' }) },
+    )
+    expect(wrapper.find('.prop-toggle').exists()).toBe(true)
+    expect(wrapper.find('.slot-toggle').exists()).toBe(false)
+  })
+
+  it('Stepper.Step: step level #icon slot is not shadowed by the injected step number', () => {
+    const wrapper = withProvider(
+      Stepper,
+      { active: 0 },
+      {
+        default: () => [
+          h(
+            StepperStep,
+            { label: 'Step 1' },
+            { icon: () => h('span', { class: 'slot-icon' }, 'A') },
+          ),
+          h(StepperStep, { label: 'Step 2' }),
+        ],
+      },
+    )
+
+    expect(wrapper.find('.slot-icon').exists()).toBe(true)
+    // The step without its own icon still falls back to the step number
+    expect(wrapper.text()).toContain('2')
+  })
+
+  it('Stepper.Step: step icon prop wins over the step #icon slot', () => {
+    const wrapper = withProvider(
+      Stepper,
+      { active: 0 },
+      {
+        default: () => [
+          h(
+            StepperStep,
+            { label: 'Step 1', icon: h('span', { class: 'prop-icon' }) },
+            { icon: () => h('span', { class: 'slot-icon' }) },
+          ),
+        ],
+      },
+    )
+
+    expect(wrapper.find('.prop-icon').exists()).toBe(true)
+    expect(wrapper.find('.slot-icon').exists()).toBe(false)
+  })
+
+  it('Stepper: root #icon slot is the fallback for steps without their own icon slot', () => {
+    const wrapper = withProvider(
+      Stepper,
+      { active: 0 },
+      {
+        default: () => [
+          h(StepperStep, { label: 'Step 1' }, { icon: () => h('span', { class: 'own-icon' }) }),
+          h(StepperStep, { label: 'Step 2' }),
+        ],
+        icon: () => h('span', { class: 'inherited-icon' }),
+      },
+    )
+
+    expect(wrapper.findAll('.own-icon')).toHaveLength(1)
+    expect(wrapper.findAll('.inherited-icon')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Summary

Makes the library more Vue-friendly by allowing custom content through named slots
instead of only VNode-based props, and updates the documentation demos to show the
slot form first.

Existing VNode props are fully backwards compatible everywhere , props keep
precedence over slots, matching `resolveNode`.

## New named slots (`@mantine-vue/core`)

| Component | Slot(s) |
| --- | --- |
| `Accordion` | `#chevron` (root level, applies to every `Accordion.Control`) |
| `ColorInput` | `#eyeDropperIcon` |
| `Scroller` | `#startControlIcon`, `#endControlIcon` |
| `Splitter` | `#handleIcon` |
| `Textarea` | `#bottomSection` |
| `PasswordInput` | `#visibilityToggleIcon` (scoped, receives `{ reveal }`) |


## Documentation

Demos now show both supported approaches with the slot-based example first, or
the slot-based approach alone where showing both would make the demo too long.