### PR TITLE
[release] Version: 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-vue",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "private": true,
   "description": "Mantine vue Components Monorepo ported of Mantine React",
   "license": "MIT",

--- a/packages/@mantine-vue/carousel/package.json
+++ b/packages/@mantine-vue/carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/carousel",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Embla based carousel, Vue equivalent to @mantine/carousel",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "embla-carousel": ">=8.0.0",
     "embla-carousel-vue": ">=8.0.0",
     "vue": "^3.5.0"

--- a/packages/@mantine-vue/charts/package.json
+++ b/packages/@mantine-vue/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/charts",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Charts components built with Apache ECharts and Mantine Vue",
   "license": "MIT",
   "files": [
@@ -38,7 +38,7 @@
     "vue-echarts": "^8.0.1"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
     "echarts": ">=6.0.0",
     "vue": "^3.5.0",
     "vue-echarts": ">=8.0.0"

--- a/packages/@mantine-vue/code-highlight/package.json
+++ b/packages/@mantine-vue/code-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/code-highlight",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue code highlight components equivalent to @mantine/code-highlight",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/colors-generator/package.json
+++ b/packages/@mantine-vue/colors-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/colors-generator",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A library to generate 10 shades of color based on provided color value",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/contextmenu/package.json
+++ b/packages/@mantine-vue/contextmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/contextmenu",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Desktop-grade context menu extension for Mantine Vue",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "vue": "^3.5.0"
   },
   "mantineVue": {

--- a/packages/@mantine-vue/core/package.json
+++ b/packages/@mantine-vue/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/core",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue component foundation architecturally equivalent to @mantine/core",
   "license": "MIT",
   "files": [
@@ -44,8 +44,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/hooks": "2.3.1",
-    "@mantine-vue/utils": "2.3.1",
+    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/utils": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/dates/package.json
+++ b/packages/@mantine-vue/dates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/dates",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue date and time picker components equivalent to @mantine/dates",
   "license": "MIT",
   "files": [
@@ -40,8 +40,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "dayjs": ">=1.0.0",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/dropzone/package.json
+++ b/packages/@mantine-vue/dropzone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/dropzone",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue file drag & drop zone component equivalent to @mantine/dropzone",
   "license": "MIT",
   "files": [
@@ -37,8 +37,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/form/package.json
+++ b/packages/@mantine-vue/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/form",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue form management package equivalent to @mantine/form",
   "license": "MIT",
   "files": [
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@mantine-vue/utils": "2.3.1"
+    "@mantine-vue/utils": "2.4.0"
   },
   "devDependencies": {
     "@mantine-vue/utils": "workspace:*",

--- a/packages/@mantine-vue/hooks/package.json
+++ b/packages/@mantine-vue/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/hooks",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue composables equivalent to @mantine/hooks",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/mantine-header/package.json
+++ b/packages/@mantine-vue/mantine-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/mantine-header",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Components used in headers of *.mantine.dev websites (Vue port of @mantinex/mantine-header)",
   "license": "MIT",
   "files": [
@@ -35,7 +35,7 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
     "@phosphor-icons/vue": "^2.2",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/modals/package.json
+++ b/packages/@mantine-vue/modals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/modals",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue modals management system equivalent to @mantine/modals",
   "license": "MIT",
   "files": [
@@ -35,8 +35,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/store": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/store": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/notifications/package.json
+++ b/packages/@mantine-vue/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/notifications",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue notifications system equivalent to @mantine/notifications",
   "license": "MIT",
   "files": [
@@ -40,9 +40,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
-    "@mantine-vue/store": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/store": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/nprogress/package.json
+++ b/packages/@mantine-vue/nprogress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/nprogress",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue navigation progress bar equivalent to @mantine/nprogress",
   "license": "MIT",
   "files": [
@@ -37,8 +37,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/store": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/store": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/schedule/package.json
+++ b/packages/@mantine-vue/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/schedule",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue schedule and calendar components equivalent to @mantine/schedule",
   "license": "MIT",
   "files": [
@@ -44,9 +44,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/dates": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/dates": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "dayjs": ">=1.0.0",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/spotlight/package.json
+++ b/packages/@mantine-vue/spotlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/spotlight",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue command center components equivalent to @mantine/spotlight",
   "license": "MIT",
   "files": [
@@ -36,9 +36,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
-    "@mantine-vue/store": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/store": "2.4.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/store/package.json
+++ b/packages/@mantine-vue/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/store",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "External store primitive for later extension packages",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/table/package.json
+++ b/packages/@mantine-vue/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/table",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A fully featured Vue 3 implementation of TanStack Vue Table",
   "keywords": [
     "data grid",
@@ -65,9 +65,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/dates": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/dates": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "@tabler/icons-vue": ">=3.0.0",
     "@tanstack/match-sorter-utils": ">=8.7",
     "@tanstack/vue-table": ">=8.20",

--- a/packages/@mantine-vue/tiptap/package.json
+++ b/packages/@mantine-vue/tiptap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/tiptap",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vue rich text editor based on tiptap, equivalent to @mantine/tiptap",
   "license": "MIT",
   "files": [
@@ -45,8 +45,8 @@
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.0.0",
-    "@mantine-vue/core": "2.3.1",
-    "@mantine-vue/hooks": "2.3.1",
+    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/hooks": "2.4.0",
     "@tiptap/core": ">=3.3.0",
     "@tiptap/extension-link": ">=3.3.0",
     "@tiptap/pm": ">=3.3.0",

--- a/packages/@mantine-vue/utils/package.json
+++ b/packages/@mantine-vue/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/utils",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Framework-independent utilities ported from Mantine foundation",
   "license": "MIT",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,8 +562,8 @@ __metadata:
     embla-carousel-vue: "npm:^8.6.0"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     embla-carousel: ">=8.0.0"
     embla-carousel-vue: ">=8.0.0"
     vue: ^3.5.0
@@ -579,7 +579,7 @@ __metadata:
     vue: "npm:^3.5.0"
     vue-echarts: "npm:^8.0.1"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
+    "@mantine-vue/core": 2.4.0
     echarts: ">=6.0.0"
     vue: ^3.5.0
     vue-echarts: ">=8.0.0"
@@ -596,8 +596,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -623,8 +623,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -641,8 +641,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/hooks": 2.3.1
-    "@mantine-vue/utils": 2.3.1
+    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/utils": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -658,8 +658,8 @@ __metadata:
     dayjs: "npm:^1.11.21"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     dayjs: ">=1.0.0"
     vue: ^3.5.0
   languageName: unknown
@@ -746,8 +746,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -782,7 +782,7 @@ __metadata:
     "@phosphor-icons/vue": "npm:^2.2"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
+    "@mantine-vue/core": 2.4.0
     "@phosphor-icons/vue": ^2.2
     vue: ^3.5.0
   languageName: unknown
@@ -798,8 +798,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/store": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/store": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -815,9 +815,9 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
-    "@mantine-vue/store": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/store": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -832,8 +832,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/store": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/store": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -851,9 +851,9 @@ __metadata:
     rrule: "npm:^2.8.1"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/dates": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/dates": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     dayjs: ">=1.0.0"
     vue: ^3.5.0
   languageName: unknown
@@ -921,9 +921,9 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
-    "@mantine-vue/store": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/store": 2.4.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -955,9 +955,9 @@ __metadata:
     dayjs: "npm:^1.11.21"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/dates": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/dates": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     "@tabler/icons-vue": ">=3.0.0"
     "@tanstack/match-sorter-utils": ">=8.7"
     "@tanstack/vue-table": ">=8.20"
@@ -984,8 +984,8 @@ __metadata:
     vue: "npm:^3.5.0"
   peerDependencies:
     "@floating-ui/dom": ^1.0.0
-    "@mantine-vue/core": 2.3.1
-    "@mantine-vue/hooks": 2.3.1
+    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/hooks": 2.4.0
     "@tiptap/core": ">=3.3.0"
     "@tiptap/extension-link": ">=3.3.0"
     "@tiptap/pm": ">=3.3.0"


### PR DESCRIPTION
# Mantine Vue 2.4.0

Mantine Vue 2.4.0 aligns the project with the applicable changes from Mantine React
9.4.1 through 9.5.0. This release introduces Cascader, resizable floating windows,
broader named-slot support, new date-picker and layout capabilities, and multiple
accessibility and rendering fixes.

## Highlights

### New Cascader component

`@mantine-vue/core` now includes `Cascader`, a hierarchical selection component 

### Resizable FloatingWindow

`FloatingWindow` now supports resizing through the new

## New features

### Named slots

Named-slot coverage was expanded across the component library while preserving all
existing prop APIs:

- Accordion
- ColorInput
- ComboboxPopover
- MultiSelect
- PasswordInput
- RangeSlider
- Scroller
- Select
- Slider
- Splitter
- Stepper
- TagsInput
- Textarea
- Tree and TreeSelect
- ChartTooltip
- CodeHighlight and CodeHighlightTabs
- Context menu items
- Dropzone status content

### Dates

Calendar, DatePicker, MonthPicker, YearPicker, and their input variants now support
native month and year selectors with:

- `withNativeLevelSelect`
- `yearsSelectRange`

### Timeline

Timeline now supports:

- Opposite-side item content through props and the `opposite` named slot
- Alternating item layout

### Accordion and mounted content

- Accordion now supports `disableCollapse`
- `keepMounted` support was added to Accordion, Collapse, Modal, Drawer, ModalBase,
  and Transition APIs

### ScrollArea

Added `verticalScrollbarPosition` to place the vertical scrollbar on either side of
the viewport.

### TreeSelect

- Custom tree render nodes receive expansion state and controls
- Empty child arrays are handled as leaf nodes

### Schedule

Schedule views now include:

- Whole-hour intervals through 24 hours
- A minimum visible size for short events
- Trailing-inset positioning to avoid viewport overflow
- Responsive border radius and padding for small events

## Fixes

- Fixed Slider and RangeSlider mark-label positioning in RTL layouts
- Fixed RollingNumber rendering `-0` after rounding negative values
- Added `role="presentation"` to the Menu initial-focus placeholder
- Improved icon and render-content handling throughout component demos
- Corrected TreeSelect behavior for empty children
- Improved date-selector disabled-state handling

## Pull requests

- [#44 – Named slot support](https://github.com/hasan-alhawaj/mantine-vue/pull/44)
- [#45 – Accordion disable collapse](https://github.com/hasan-alhawaj/mantine-vue/pull/45)
- [#46 – Keep mounted support](https://github.com/hasan-alhawaj/mantine-vue/pull/46)
- [#47 – Timeline opposite and alternate content](https://github.com/hasan-alhawaj/mantine-vue/pull/47)
- [#48 – RollingNumber negative-zero fix](https://github.com/hasan-alhawaj/mantine-vue/pull/48)
- [#49 – Native date-picker selectors](https://github.com/hasan-alhawaj/mantine-vue/pull/49)
- [#50 – Slider RTL label fix](https://github.com/hasan-alhawaj/mantine-vue/pull/50)
- [#51 – Menu initial-focus accessibility](https://github.com/hasan-alhawaj/mantine-vue/pull/51)
- [#52 – ScrollArea vertical scrollbar position](https://github.com/hasan-alhawaj/mantine-vue/pull/52)
- [#53 – TreeSelect expansion behavior](https://github.com/hasan-alhawaj/mantine-vue/pull/53)
- [#54 – FormProviderProps export](https://github.com/hasan-alhawaj/mantine-vue/pull/54)
- [#55 – Schedule updates](https://github.com/hasan-alhawaj/mantine-vue/pull/55)
- [#56 – Resizable FloatingWindow](https://github.com/hasan-alhawaj/mantine-vue/pull/56)
- [#57 – Cascader component](https://github.com/hasan-alhawaj/mantine-vue/pull/57)

**Full changelog:** [v2.3.1...v2.4.0](https://github.com/hasan-alhawaj/mantine-vue/compare/v2.3.1...v2.4.0)
