### PR TITLE
feat!: add idiomatic v-model support to form controls

### DIFF
--- a/apps/mantine.dev/src/components/ColorsGenerator/ColorsInput/ColorsInput.ts
+++ b/apps/mantine.dev/src/components/ColorsGenerator/ColorsInput/ColorsInput.ts
@@ -92,8 +92,7 @@ export const ColorsInput = defineComponent({
             label: 'Display colors info',
             size: 'md',
             checked: props.displayColorsInfo,
-            onChange: (event: Event) =>
-              props.setDisplayColorsInfo((event.currentTarget as HTMLInputElement).checked),
+            onChange: (checked: boolean) => props.setDisplayColorsInfo(checked),
             mt: 'xl',
           }),
           h(

--- a/apps/mantine.dev/src/demo/controls/ConfiguratorBooleanControl.ts
+++ b/apps/mantine.dev/src/demo/controls/ConfiguratorBooleanControl.ts
@@ -15,8 +15,7 @@ export const ConfiguratorBooleanControl = defineComponent({
       h(Switch, {
         ...attrs,
         checked: props.value,
-        onChange: (event: Event) =>
-          props.onChange((event.currentTarget as HTMLInputElement).checked),
+        onChange: (checked: boolean) => props.onChange(checked),
         label: getControlLabel(props.prop),
       })
   },

--- a/apps/mantine.dev/src/demo/controls/ConfiguratorColorControl.ts
+++ b/apps/mantine.dev/src/demo/controls/ConfiguratorColorControl.ts
@@ -69,14 +69,13 @@ export const ConfiguratorColorControl = defineComponent({
                   ),
                   h(Popover.Dropdown, { p: 8 }, () => [
                     h(ColorPicker, {
-                      value: colorPickerColor.value,
-                      onChange: handleColorPickerChange,
+                      modelValue: colorPickerColor.value,
+                      'onUpdate:modelValue': handleColorPickerChange,
                       format: 'rgba',
                     }),
                     h(TextInput, {
-                      value: colorPickerColor.value,
-                      onChange: (event: Event) =>
-                        handleColorPickerChange((event.currentTarget as HTMLInputElement).value),
+                      modelValue: colorPickerColor.value,
+                      'onUpdate:modelValue': handleColorPickerChange,
                       placeholder: 'Enter color',
                       radius: 'md',
                       size: 'xs',

--- a/apps/mantine.dev/src/demo/controls/ConfiguratorSelectControl.ts
+++ b/apps/mantine.dev/src/demo/controls/ConfiguratorSelectControl.ts
@@ -17,8 +17,7 @@ export const ConfiguratorSelectControl = defineComponent({
       h(NativeSelect, {
         ...attrs,
         value: props.value,
-        onChange: (event: Event) =>
-          props.onChange((event.currentTarget as HTMLSelectElement).value),
+        onChange: (value: string) => props.onChange(value),
         label: getControlLabel(props.prop),
         data: transformSelectData(props.data),
       })

--- a/apps/mantine.dev/src/demo/controls/ConfiguratorStringControl.ts
+++ b/apps/mantine.dev/src/demo/controls/ConfiguratorStringControl.ts
@@ -14,8 +14,8 @@ export const ConfiguratorStringControl = defineComponent({
     return () =>
       h(TextInput, {
         ...attrs,
-        value: props.value,
-        onChange: (event: Event) => props.onChange((event.currentTarget as HTMLInputElement).value),
+        modelValue: props.value,
+        'onUpdate:modelValue': (value: string) => props.onChange(value),
         label: getControlLabel(props.prop),
         placeholder: 'Enter prop value',
       })

--- a/apps/mantine.dev/src/demos/core/ActionIcon/ActionIcon.demo.loading.ts
+++ b/apps/mantine.dev/src/demos/core/ActionIcon/ActionIcon.demo.loading.ts
@@ -40,7 +40,7 @@ const loading = ref(false)
     </ActionIcon>
   </Group>
 
-  <Switch :checked="loading" @change="loading = !loading" label="Loading state" mt="md" />
+  <Switch v-model="loading" label="Loading state" mt="md" />
 </template>
 `
 
@@ -70,9 +70,9 @@ const Demo = defineComponent({
           ],
         }),
         h(Switch, {
-          checked: loading.value,
-          onChange: () => {
-            loading.value = !loading.value
+          modelValue: loading.value,
+          'onUpdate:modelValue': (value: boolean) => {
+            loading.value = value
           },
           label: 'Loading state',
           mt: 'md',

--- a/apps/mantine.dev/src/demos/core/AngleSlider/AngleSlider.demo.onChangeEnd.ts
+++ b/apps/mantine.dev/src/demos/core/AngleSlider/AngleSlider.demo.onChangeEnd.ts
@@ -13,8 +13,7 @@ const endValue = ref(0)
 
 <template>
   <AngleSlider
-    :value="value"
-    @change="(v) => (value = v)"
+    v-model="value"
     @change-end="(v) => (endValue = v)"
   />
   <Text mt="md">Current value: {{ value }}</Text>
@@ -30,8 +29,8 @@ const Demo = defineComponent({
     return () =>
       h('div', null, [
         h(AngleSlider, {
-          value: value.value,
-          onChange: (v: number) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: number) => {
             value.value = v
           },
           onChangeEnd: (v: number) => {

--- a/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.card.ts
+++ b/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.card.ts
@@ -83,8 +83,7 @@ const checked = ref(false)
 <template>
   <Checkbox.Card
     :class="classes.root"
-    :checked="checked"
-    @click="checked = !checked"
+    v-model="checked"
   >
     <Group wrap="nowrap" align="flex-start">
       <Checkbox.Indicator />
@@ -110,9 +109,9 @@ const Demo = defineComponent({
         Checkbox.Card,
         {
           class: 'checkbox-card-demo-root',
-          checked: checked.value,
-          onClick: () => {
-            checked.value = !checked.value
+          modelValue: checked.value,
+          'onUpdate:modelValue': (value: boolean) => {
+            checked.value = value
           },
         },
         {

--- a/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.cardGroup.ts
+++ b/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.cardGroup.ts
@@ -89,8 +89,7 @@ const value = ref<string[]>([])
 <template>
   <div>
     <CheckboxGroup
-      :value="value"
-      @change="value = $event"
+      v-model="value"
       label="Pick packages to install"
       description="Choose all packages that you will need in your application"
     >
@@ -171,8 +170,8 @@ const Demo = defineComponent({
         h(
           CheckboxGroup,
           {
-            value: value.value,
-            onChange: (v: string[]) => {
+            modelValue: value.value,
+            'onUpdate:modelValue': (v: string[]) => {
               value.value = v
             },
             label: 'Pick packages to install',

--- a/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.customize.ts
+++ b/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.customize.ts
@@ -67,7 +67,7 @@ const checked = ref(false)
     :classNames="{ root: classes.root }"
     label="Checkbox button"
     :checked="checked"
-    @change="(e) => (checked = e.target.checked)"
+    @change="(value) => (checked = value)"
     :wrapperProps="{ onClick: () => (checked = !checked) }"
   />
 </template>
@@ -84,8 +84,8 @@ const Demo = defineComponent({
         classNames: { root: 'checkbox-customize-demo-root' },
         label: 'Checkbox button',
         checked: checked.value,
-        onChange: (e: Event) => {
-          checked.value = (e.target as HTMLInputElement).checked
+        onChange: (value: boolean) => {
+          checked.value = value
         },
         wrapperProps: {
           onClick: () => {

--- a/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.indeterminate.ts
+++ b/apps/mantine.dev/src/demos/core/Checkbox/Checkbox.demo.indeterminate.ts
@@ -37,7 +37,7 @@ const toggleAll = () => {
       :ml="33"
       :label="item.label"
       :checked="item.checked"
-      @change="(e) => { values[index] = { ...values[index], checked: e.target.checked } }"
+      @change="(checked) => { values[index] = { ...values[index], checked } }"
     />
   </div>
 </template>
@@ -79,8 +79,7 @@ const Demo = defineComponent({
                 ml: 33,
                 label: item.label,
                 checked: item.checked,
-                onChange: (e: Event) => {
-                  const checked = (e.target as HTMLInputElement).checked
+                onChange: (checked: boolean) => {
                   values.value = values.value.map((v, i) => (i === index ? { ...v, checked } : v))
                 },
               }),

--- a/apps/mantine.dev/src/demos/core/Chip/Chip.demo.deselect.ts
+++ b/apps/mantine.dev/src/demos/core/Chip/Chip.demo.deselect.ts
@@ -17,7 +17,7 @@ const handleChipClick = (chipValue: string) => {
 </script>
 
 <template>
-  <ChipGroup :multiple="false" :value="value" @change="value = $event">
+  <ChipGroup v-model="value" :multiple="false">
     <Group>
       <Chip value="first" @click.capture="handleChipClick('first')">First</Chip>
       <Chip value="second" @click.capture="handleChipClick('second')">Second</Chip>
@@ -43,8 +43,8 @@ const Demo = defineComponent({
         ChipGroup,
         {
           multiple: false,
-          value: value.value,
-          onChange: (v: string | string[]) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: string | string[]) => {
             value.value = v as string
           },
         },

--- a/apps/mantine.dev/src/demos/core/ColorPicker/ColorPicker.demo.alphaSlider.ts
+++ b/apps/mantine.dev/src/demos/core/ColorPicker/ColorPicker.demo.alphaSlider.ts
@@ -12,7 +12,7 @@ const value = ref(0.55)
 
 <template>
   <Text>Alpha value: {{ value }}</Text>
-  <AlphaSlider color="#1c7ed6" :value="value" @change="value = $event" />
+  <AlphaSlider v-model="value" color="#1c7ed6" />
 </template>
 `
 
@@ -25,8 +25,8 @@ const Demo = defineComponent({
         h(Text, {}, { default: () => `Alpha value: ${value.value}` }),
         h(AlphaSlider, {
           color: '#1c7ed6',
-          value: value.value,
-          onChange: (v: number) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: number) => {
             value.value = v
           },
         }),

--- a/apps/mantine.dev/src/demos/core/ColorPicker/ColorPicker.demo.hueSlider.ts
+++ b/apps/mantine.dev/src/demos/core/ColorPicker/ColorPicker.demo.hueSlider.ts
@@ -13,7 +13,7 @@ const value = ref(250)
 <template>
   <div>
     <Text>Hue value: {{ value }}</Text>
-    <HueSlider :value="value" @change="value = $event" />
+    <HueSlider v-model="value" />
   </div>
 </template>
 `
@@ -26,8 +26,8 @@ const Demo = defineComponent({
       h('div', null, [
         h(Text, {}, { default: () => `Hue value: ${value.value}` }),
         h(HueSlider, {
-          value: value.value,
-          onChange: (v: number) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: number) => {
             value.value = v
           },
         }),

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.allowDeselect.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.allowDeselect.ts
@@ -14,10 +14,9 @@ const value2 = ref<string | null>('React')
 <template>
   <Stack>
     <ComboboxPopover
+      v-model="value1"
       :data="['React', 'Angular', 'Vue', 'Svelte']"
-      :value="value1"
       :allow-deselect="false"
-      @change="value1 = $event"
     >
       <ComboboxPopover.Target>
         <Button variant="default" :miw="200">{{ value1 || 'Cannot deselect' }}</Button>
@@ -25,10 +24,9 @@ const value2 = ref<string | null>('React')
     </ComboboxPopover>
 
     <ComboboxPopover
+      v-model="value2"
       :data="['React', 'Angular', 'Vue', 'Svelte']"
-      :value="value2"
       allow-deselect
-      @change="value2 = $event"
     >
       <ComboboxPopover.Target>
         <Button variant="default" :miw="200">{{ value2 || 'Can deselect (default)' }}</Button>
@@ -49,9 +47,9 @@ const Demo = defineComponent({
           ComboboxPopover,
           {
             data: ['React', 'Angular', 'Vue', 'Svelte'],
-            value: value1.value,
+            modelValue: value1.value,
             allowDeselect: false,
-            onChange: (val: string | null) => {
+            'onUpdate:modelValue': (val: string | null) => {
               value1.value = val
             },
           },
@@ -64,9 +62,9 @@ const Demo = defineComponent({
           ComboboxPopover,
           {
             data: ['React', 'Angular', 'Vue', 'Svelte'],
-            value: value2.value,
+            modelValue: value2.value,
             allowDeselect: true,
-            onChange: (val: string | null) => {
+            'onUpdate:modelValue': (val: string | null) => {
               value2.value = val
             },
           },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.controlledSearch.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.controlledSearch.ts
@@ -13,11 +13,10 @@ const searchValue = ref('')
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="['React', 'Angular', 'Vue', 'Svelte']"
-    :value="value"
     searchable
     :search-value="searchValue"
-    @change="value = $event"
     @search-change="searchValue = $event"
   >
     <ComboboxPopover.Target>
@@ -41,10 +40,10 @@ const Demo = defineComponent({
           ComboboxPopover,
           {
             data: ['React', 'Angular', 'Vue', 'Svelte'],
-            value: value.value,
+            modelValue: value.value,
             searchable: true,
             searchValue: searchValue.value,
-            onChange: (val: string | null) => {
+            'onUpdate:modelValue': (val: string | null) => {
               value.value = val
             },
             onSearchChange: (val: string) => {

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.formSubmission.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.formSubmission.ts
@@ -21,10 +21,9 @@ function handleSubmit(event: Event) {
   <form @submit="handleSubmit">
     <Stack>
       <ComboboxPopover
+        v-model="value"
         :data="['React', 'Angular', 'Vue', 'Svelte']"
-        :value="value"
         name="framework"
-        @change="value = $event"
       >
         <ComboboxPopover.Target>
           <Button variant="default" :miw="200" type="button">
@@ -59,9 +58,9 @@ const Demo = defineComponent({
             ComboboxPopover,
             {
               data: ['React', 'Angular', 'Vue', 'Svelte'],
-              value: value.value,
+              modelValue: value.value,
               name: 'framework',
-              onChange: (val: string | null) => {
+              'onUpdate:modelValue': (val: string | null) => {
                 value.value = val
               },
             },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.groups.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.groups.ts
@@ -16,7 +16,7 @@ const data = [
 </script>
 
 <template>
-  <ComboboxPopover :data="data" :value="value" @change="value = $event">
+  <ComboboxPopover v-model="value" :data="data">
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select technology' }}</Button>
     </ComboboxPopover.Target>
@@ -38,8 +38,8 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data,
-          value: value.value,
-          onChange: (val: string | null) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.limit.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.limit.ts
@@ -16,12 +16,11 @@ const largeData = Array(1000)
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="largeData"
-    :value="value"
     searchable
     :limit="5"
     nothing-found-message="Nothing found..."
-    @change="value = $event"
   >
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select option' }}</Button>
@@ -43,11 +42,11 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data: largeData,
-          value: value.value,
+          modelValue: value.value,
           searchable: true,
           limit: 5,
           nothingFoundMessage: 'Nothing found...',
-          onChange: (val: string | null) => {
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.multiple.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.multiple.ts
@@ -12,10 +12,9 @@ const value = ref<string[]>([])
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="['React', 'Angular', 'Vue', 'Svelte']"
-    :value="value"
     multiple
-    @change="value = $event"
   >
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">
@@ -35,9 +34,9 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data: ['React', 'Angular', 'Vue', 'Svelte'],
-          value: value.value,
+          modelValue: value.value,
           multiple: true,
-          onChange: (val: string[]) => {
+          'onUpdate:modelValue': (val: string[]) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.renderOption.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.renderOption.ts
@@ -48,7 +48,7 @@ function renderOption({ option, checked }: ComboboxLikeRenderOptionInput<Combobo
 </script>
 
 <template>
-  <ComboboxPopover :data="data" :value="value" :render-option="renderOption" @change="value = $event">
+  <ComboboxPopover v-model="value" :data="data" :render-option="renderOption">
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select alignment' }}</Button>
     </ComboboxPopover.Target>
@@ -93,9 +93,9 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data,
-          value: value.value,
+          modelValue: value.value,
           renderOption: renderSelectOption as any,
-          onChange: (val: string | null) => {
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.searchable.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.searchable.ts
@@ -12,11 +12,10 @@ const value = ref<string | null>(null)
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="['React', 'Angular', 'Vue', 'Svelte']"
-    :value="value"
     searchable
     nothing-found-message="Nothing found..."
-    @change="value = $event"
   >
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select framework' }}</Button>
@@ -34,10 +33,10 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data: ['React', 'Angular', 'Vue', 'Svelte'],
-          value: value.value,
+          modelValue: value.value,
           searchable: true,
           nothingFoundMessage: 'Nothing found...',
-          onChange: (val: string | null) => {
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.sort.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.sort.ts
@@ -23,12 +23,11 @@ const optionsFilter: OptionsFilter<Primitive> = ({ options, search }) => {
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="['4 – React', '1 – Angular', '3 – Vue', '2 – Svelte']"
-    :value="value"
     searchable
     :filter="optionsFilter"
     nothing-found-message="Nothing found..."
-    @change="value = $event"
   >
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select framework' }}</Button>
@@ -55,11 +54,11 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data: ['4 – React', '1 – Angular', '3 – Vue', '2 – Svelte'],
-          value: value.value,
+          modelValue: value.value,
           searchable: true,
           filter: optionsFilter,
           nothingFoundMessage: 'Nothing found...',
-          onChange: (val: string | null) => {
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.usage.ts
+++ b/apps/mantine.dev/src/demos/core/ComboboxPopover/ComboboxPopover.demo.usage.ts
@@ -12,9 +12,8 @@ const value = ref<string | null>(null)
 
 <template>
   <ComboboxPopover
+    v-model="value"
     :data="['React', 'Angular', 'Vue', 'Svelte']"
-    :value="value"
-    @change="value = $event"
   >
     <ComboboxPopover.Target>
       <Button variant="default" :miw="200">{{ value || 'Select framework' }}</Button>
@@ -32,8 +31,8 @@ const Demo = defineComponent({
         ComboboxPopover,
         {
           data: ['React', 'Angular', 'Vue', 'Svelte'],
-          value: value.value,
-          onChange: (val: string | null) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (val: string | null) => {
             value.value = val
           },
         },

--- a/apps/mantine.dev/src/demos/core/FloatingWindow/FloatingWindow.demo.axis.ts
+++ b/apps/mantine.dev/src/demos/core/FloatingWindow/FloatingWindow.demo.axis.ts
@@ -25,7 +25,7 @@ const axis = ref<'x' | 'y'>('y')
     <Button variant="default" @click="handlers.toggle">
       {{ visible ? 'Hide' : 'Show' }} floating window
     </Button>
-    <SegmentedControl :data="['x', 'y']" :value="axis" @change="(val) => axis = val as 'x' | 'y'" />
+    <SegmentedControl v-model="axis" :data="['x', 'y']" />
   </Group>
 
   <FloatingWindow
@@ -64,8 +64,8 @@ const Demo = defineComponent({
             ),
             h(SegmentedControl, {
               data: ['x', 'y'],
-              value: axis.value,
-              onChange: (val: string) => {
+              modelValue: axis.value,
+              'onUpdate:modelValue': (val: string) => {
                 axis.value = val as 'x' | 'y'
               },
             }),

--- a/apps/mantine.dev/src/demos/core/FloatingWindow/FloatingWindow.demo.enabled.ts
+++ b/apps/mantine.dev/src/demos/core/FloatingWindow/FloatingWindow.demo.enabled.ts
@@ -18,7 +18,7 @@ const enabled = ref(true)
     <Button variant="default" @click="handlers.toggle">
       {{ visible ? 'Hide' : 'Show' }} floating window
     </Button>
-    <Chip :checked="enabled" @change="enabled = !enabled">
+    <Chip v-model="enabled">
       Drag {{ enabled ? 'enabled' : 'disabled' }}
     </Chip>
   </Group>
@@ -58,9 +58,9 @@ const Demo = defineComponent({
             h(
               Chip,
               {
-                checked: enabled.value,
-                onChange: () => {
-                  enabled.value = !enabled.value
+                modelValue: enabled.value,
+                'onUpdate:modelValue': (value: boolean) => {
+                  enabled.value = value
                 },
               },
               () => `Drag ${enabled.value ? 'enabled' : 'disabled'}`,

--- a/apps/mantine.dev/src/demos/core/Menu/Menu.demo.search.ts
+++ b/apps/mantine.dev/src/demos/core/Menu/Menu.demo.search.ts
@@ -25,11 +25,7 @@ const items = computed(() =>
     </Menu.Target>
 
     <Menu.Dropdown>
-      <Menu.Search
-        :value="query"
-        @change="(e) => query = e.target.value"
-        placeholder="Search items"
-      />
+      <Menu.Search v-model="query" placeholder="Search items" />
 
       <template v-if="items.length > 0">
         <Menu.Item v-for="item in items" :key="item">{{ item }}</Menu.Item>
@@ -74,8 +70,8 @@ const Demo = defineComponent({
                 h(Menu.Search, {
                   value: query.value,
                   placeholder: 'Search items',
-                  onChange: (e: Event) => {
-                    query.value = (e.target as HTMLInputElement).value
+                  onChange: (value: string) => {
+                    query.value = value
                   },
                 }),
                 items.length > 0

--- a/apps/mantine.dev/src/demos/core/Menu/Menu.demo.searchNested.ts
+++ b/apps/mantine.dev/src/demos/core/Menu/Menu.demo.searchNested.ts
@@ -54,7 +54,7 @@ const items = computed(() => filterTree(data, query.value.toLowerCase().trim()))
   <Menu shadow="md" :width="240">
     <Menu.Target><Button>Toggle menu</Button></Menu.Target>
     <Menu.Dropdown>
-      <Menu.Search :value="query" @change="(e) => query = e.target.value" placeholder="Search items" />
+      <Menu.Search v-model="query" placeholder="Search items" />
       <!-- render tree recursively via component -->
     </Menu.Dropdown>
   </Menu>
@@ -146,8 +146,8 @@ const Demo = defineComponent({
                 h(Menu.Search, {
                   value: query.value,
                   placeholder: 'Search items',
-                  onChange: (e: Event) => {
-                    query.value = (e.target as HTMLInputElement).value
+                  onChange: (value: string) => {
+                    query.value = value
                   },
                 }),
                 items.length > 0

--- a/apps/mantine.dev/src/demos/core/MultiSelect/MultiSelect.demo.dragReorder.ts
+++ b/apps/mantine.dev/src/demos/core/MultiSelect/MultiSelect.demo.dragReorder.ts
@@ -16,8 +16,7 @@ const value = ref(['React', 'Angular', 'Vue'])
     description="Selected values can be reordered by dragging pills"
     placeholder="Pick value"
     :data="['React', 'Angular', 'Vue', 'Svelte', 'Solid', 'Ember']"
-    :value="value"
-    @change="(v) => (value = v)"
+    v-model="value"
     with-pills-reorder
   />
 </template>
@@ -33,8 +32,8 @@ const Demo = defineComponent({
         description: 'Selected values can be reordered by dragging pills',
         placeholder: 'Pick value',
         data: ['React', 'Angular', 'Vue', 'Svelte', 'Solid', 'Ember'],
-        value: value.value,
-        onChange: (v: any[]) => {
+        modelValue: value.value,
+        'onUpdate:modelValue': (v: any[]) => {
           value.value = v.filter((item): item is string => typeof item === 'string')
         },
         withPillsReorder: true,

--- a/apps/mantine.dev/src/demos/core/NumberInput/NumberInput.demo.bigInt.ts
+++ b/apps/mantine.dev/src/demos/core/NumberInput/NumberInput.demo.bigInt.ts
@@ -14,8 +14,7 @@ const value = ref<bigint | string>(BigInt('12345678901234567890'))
   <NumberInput
     label="BigInt value"
     description="BigInt mode is inferred from defaultValue/value"
-    :value="value"
-    @change="(v) => (value = v)"
+    v-model="value"
     :step="BigInt(10)"
     :min="BigInt(0)"
     thousandSeparator=","
@@ -32,8 +31,8 @@ const Demo = defineComponent({
       h(NumberInput, {
         label: 'BigInt value',
         description: 'BigInt mode is inferred from defaultValue/value',
-        value: value.value,
-        onChange: (v: bigint | string | number) => {
+        modelValue: value.value,
+        'onUpdate:modelValue': (v: bigint | string | number) => {
           value.value = v as bigint | string
         },
         step: BigInt(10),

--- a/apps/mantine.dev/src/demos/core/PasswordInput/PasswordInput.demo.strengthMeter.ts
+++ b/apps/mantine.dev/src/demos/core/PasswordInput/PasswordInput.demo.strengthMeter.ts
@@ -52,8 +52,7 @@ const color = computed(() => strength.value === 100 ? 'teal' : strength.value > 
           withAsterisk
           label="Your password"
           placeholder="Your password"
-          :value="value"
-          @change="(e) => (value = e.target.value)"
+          v-model="value"
         />
       </div>
     </PopoverTarget>
@@ -163,8 +162,8 @@ const Demo = defineComponent({
                       label: 'Your password',
                       placeholder: 'Your password',
                       value: value.value,
-                      onChange: (event: Event) => {
-                        value.value = (event.currentTarget as HTMLInputElement).value
+                      onChange: (nextValue: string) => {
+                        value.value = nextValue
                       },
                     }),
                   ],

--- a/apps/mantine.dev/src/demos/core/Radio/Radio.demo.cardGroup.ts
+++ b/apps/mantine.dev/src/demos/core/Radio/Radio.demo.cardGroup.ts
@@ -91,8 +91,7 @@ const value = ref<string | null>(null)
 <template>
   <div>
     <Radio.Group
-      :value="value"
-      @change="(v) => (value = v)"
+      v-model="value"
       label="Pick one package to install"
       description="Choose a package that you will need in your application"
     >
@@ -174,8 +173,8 @@ const Demo = defineComponent({
         h(
           Radio.Group,
           {
-            value: value.value,
-            onChange: (v: string) => {
+            modelValue: value.value,
+            'onUpdate:modelValue': (v: string) => {
               value.value = v
             },
             label: 'Pick one package to install',

--- a/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.hiddenMarks.ts
+++ b/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.hiddenMarks.ts
@@ -17,8 +17,7 @@ const value = ref<[number, number]>([25, 75])
       value: [{{ value[0] }}, {{ value[1] }}]
     </Text>
     <RangeSlider
-      :value="value"
-      @change="(v) => (value = v)"
+      v-model="value"
       :min="0"
       :max="100"
       :step="1"
@@ -57,8 +56,8 @@ const Demo = defineComponent({
               },
             ),
             h(RangeSlider, {
-              value: value.value,
-              onChange: (v: [number, number]) => {
+              modelValue: value.value,
+              'onUpdate:modelValue': (v: [number, number]) => {
                 value.value = v
               },
               min: 0,

--- a/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.maxRange.ts
+++ b/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.maxRange.ts
@@ -14,7 +14,7 @@ const value = ref<[number, number]>([20, 80])
   <Text size="sm" mb="xs">
     Maximum range: 50 (selection cannot be wider than 50 units)
   </Text>
-  <RangeSlider :value="value" @change="(v) => (value = v)" :max-range="50" />
+  <RangeSlider v-model="value" :max-range="50" />
   <Text size="sm" mt="xs">
     Value: [{{ value[0] }}, {{ value[1] }}] - Range: {{ value[1] - value[0] }}
   </Text>
@@ -35,8 +35,8 @@ const Demo = defineComponent({
           },
         ),
         h(RangeSlider, {
-          value: value.value,
-          onChange: (v: [number, number]) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: [number, number]) => {
             value.value = v
           },
           maxRange: 50,

--- a/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.minRange.ts
+++ b/apps/mantine.dev/src/demos/core/RangeSlider/RangeSlider.demo.minRange.ts
@@ -14,7 +14,7 @@ const value = ref<[number, number]>([30, 60])
   <Text size="sm" mb="xs">
     Minimum range: 20 (thumbs must be at least 20 units apart)
   </Text>
-  <RangeSlider :value="value" @change="(v) => (value = v)" :min-range="20" />
+  <RangeSlider v-model="value" :min-range="20" />
   <Text size="sm" mt="xs">
     Value: [{{ value[0] }}, {{ value[1] }}] - Range: {{ value[1] - value[0] }}
   </Text>
@@ -35,8 +35,8 @@ const Demo = defineComponent({
           },
         ),
         h(RangeSlider, {
-          value: value.value,
-          onChange: (v: [number, number]) => {
+          modelValue: value.value,
+          'onUpdate:modelValue': (v: [number, number]) => {
             value.value = v
           },
           minRange: 20,

--- a/apps/mantine.dev/src/demos/core/Rating/Rating.demo.allowClear.ts
+++ b/apps/mantine.dev/src/demos/core/Rating/Rating.demo.allowClear.ts
@@ -13,7 +13,7 @@ const value = ref(3)
 <template>
   <Stack gap="md" align="center">
     <Text size="sm">Click the same star to clear the rating</Text>
-    <Rating :value="value" @change="(v) => (value = v)" allow-clear />
+    <Rating v-model="value" allow-clear />
     <Group gap="xs">
       <Text size="sm" c="dimmed">Current rating:</Text>
       <Text size="sm" fw={600}>{{ value === 0 ? 'Not rated' : value }}</Text>
@@ -34,8 +34,8 @@ const Demo = defineComponent({
           default: () => [
             h(Text, { size: 'sm' }, { default: () => 'Click the same star to clear the rating' }),
             h(Rating, {
-              value: value.value,
-              onChange: (v: number) => {
+              modelValue: value.value,
+              'onUpdate:modelValue': (v: number) => {
                 value.value = v
               },
               allowClear: true,

--- a/apps/mantine.dev/src/demos/core/Slider/Slider.demo.changeEnd.ts
+++ b/apps/mantine.dev/src/demos/core/Slider/Slider.demo.changeEnd.ts
@@ -13,13 +13,13 @@ const endValue = ref(50)
 
 <template>
   <Box maw="400" mx="auto">
-    <Slider :value="value" @change="(v) => (value = v)" @change-end="(v) => (endValue = v)" />
+    <Slider v-model="value" @change-end="(v) => (endValue = v)" />
 
     <Text mt="md" size="sm">
-      onChange value: <b>{{ value }}</b>
+      Current value: <b>{{ value }}</b>
     </Text>
     <Text :mt="5" size="sm">
-      onChangeEnd value: <b>{{ endValue }}</b>
+      Change end value: <b>{{ endValue }}</b>
     </Text>
   </Box>
 </template>
@@ -37,8 +37,8 @@ const Demo = defineComponent({
         {
           default: () => [
             h(Slider, {
-              value: value.value,
-              onChange: (v: number) => {
+              modelValue: value.value,
+              'onUpdate:modelValue': (v: number) => {
                 value.value = v
               },
               onChangeEnd: (v: number) => {
@@ -49,14 +49,14 @@ const Demo = defineComponent({
               Text,
               { mt: 'md', size: 'sm' },
               {
-                default: () => ['onChange value: ', h('b', null, String(value.value))],
+                default: () => ['Current value: ', h('b', null, String(value.value))],
               },
             ),
             h(
               Text,
               { mt: 5, size: 'sm' },
               {
-                default: () => ['onChangeEnd value: ', h('b', null, String(endValue.value))],
+                default: () => ['Change end value: ', h('b', null, String(endValue.value))],
               },
             ),
           ],

--- a/apps/mantine.dev/src/demos/core/Slider/Slider.demo.hiddenMarks.ts
+++ b/apps/mantine.dev/src/demos/core/Slider/Slider.demo.hiddenMarks.ts
@@ -17,8 +17,7 @@ const value = ref(50)
       value: {{ value }}
     </Text>
     <Slider
-      :value="value"
-      @change="(v) => (value = v)"
+      v-model="value"
       :min="0"
       :max="100"
       :step="1"
@@ -54,8 +53,8 @@ const Demo = defineComponent({
               },
             ),
             h(Slider, {
-              value: value.value,
-              onChange: (v: number) => {
+              modelValue: value.value,
+              'onUpdate:modelValue': (v: number) => {
                 value.value = v
               },
               min: 0,

--- a/apps/mantine.dev/src/demos/core/Switch/Switch.demo.thumbIcon.ts
+++ b/apps/mantine.dev/src/demos/core/Switch/Switch.demo.thumbIcon.ts
@@ -32,8 +32,8 @@ const Demo = defineComponent({
     return () =>
       h(Switch, {
         checked: checked.value,
-        onChange: (e: Event) => {
-          checked.value = (e.target as HTMLInputElement).checked
+        onChange: (value: boolean) => {
+          checked.value = value
         },
         color: 'teal',
         size: 'md',

--- a/apps/mantine.dev/src/demos/core/Switch/Switch.demo.thumbIcon.ts
+++ b/apps/mantine.dev/src/demos/core/Switch/Switch.demo.thumbIcon.ts
@@ -31,8 +31,8 @@ const Demo = defineComponent({
     const checked = ref(false)
     return () =>
       h(Switch, {
-        checked: checked.value,
-        onChange: (value: boolean) => {
+        modelValue: checked.value,
+        'onUpdate:modelValue': (value: boolean) => {
           checked.value = value
         },
         color: 'teal',

--- a/apps/mantine.dev/src/demos/core/Table/Table.demo.rowSelection.ts
+++ b/apps/mantine.dev/src/demos/core/Table/Table.demo.rowSelection.ts
@@ -46,7 +46,7 @@ const toggleRow = (position: number, checked: boolean) => {
           <Checkbox
             aria-label="Select row"
             :checked="selectedRows.includes(el.position)"
-            @change="(e) => toggleRow(el.position, e.target.checked)"
+            @change="(checked) => toggleRow(el.position, checked)"
           />
         </Table.Td>
         <Table.Td>{{ el.position }}</Table.Td>
@@ -120,8 +120,7 @@ const Demo = defineComponent({
                                 h(Checkbox, {
                                   'aria-label': 'Select row',
                                   checked: selectedRows.value.includes(el.position),
-                                  onChange: (e: Event) =>
-                                    toggleRow(el.position, (e.target as HTMLInputElement).checked),
+                                  onChange: (checked: boolean) => toggleRow(el.position, checked),
                                 }),
                             },
                           ),

--- a/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
+++ b/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
@@ -39,8 +39,8 @@ const Demo = defineComponent({
         autosize: true,
         minRows: 4,
         value: value.value,
-        onChange: (event: Event) => {
-          value.value = (event.currentTarget as HTMLTextAreaElement).value.slice(0, maxLength)
+        onChange: (nextValue: string) => {
+          value.value = nextValue.slice(0, maxLength)
         },
         bottomSection: h(
           Text,

--- a/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
+++ b/apps/mantine.dev/src/demos/core/Textarea/Textarea.demo.bottomSection.ts
@@ -18,7 +18,7 @@ const value = ref('')
     autosize
     :min-rows="4"
     :value="value"
-    @change="(event) => (value = event.currentTarget.value.slice(0, maxLength))"
+    @change="(nextValue) => (value = nextValue.slice(0, maxLength))"
   >
     <template #bottomSection>
       <Text size="xs" c="dimmed">{{ value.length }}/{{ maxLength }} characters</Text>

--- a/apps/mantine.dev/src/demos/dates/DatePicker/index.ts
+++ b/apps/mantine.dev/src/demos/dates/DatePicker/index.ts
@@ -90,8 +90,8 @@ const PresetsDemo = defineComponent({
     const value = ref<string | null>(null)
     return () =>
       h(DatePicker, {
-        value: value.value,
-        onChange: (v: any) => (value.value = v),
+        modelValue: value.value,
+        'onUpdate:modelValue': (v: any) => (value.value = v),
         presets: [{ value: new Date().toISOString().slice(0, 10), label: 'Today' }],
       })
   },

--- a/apps/mantine.dev/src/demos/dates/MiniCalendar/index.ts
+++ b/apps/mantine.dev/src/demos/dates/MiniCalendar/index.ts
@@ -11,7 +11,7 @@ const value = ref<string | null>('2025-04-15')
 </script>
 
 <template>
-  <MiniCalendar :value="value" :number-of-days="6" @change="value = $event" />
+  <MiniCalendar v-model="value" :number-of-days="6" />
 </template>`
 
 export const usage: MantineDemo = {
@@ -22,9 +22,9 @@ export const usage: MantineDemo = {
       const value = ref<string | null>('2025-04-15')
       return () =>
         h(MiniCalendar, {
-          value: value.value,
+          modelValue: value.value,
           numberOfDays: 6,
-          onChange: (date: string) => (value.value = date),
+          'onUpdate:modelValue': (date: string | null) => (value.value = date),
         })
     },
   }),
@@ -40,8 +40,7 @@ const value = ref<string | null>('2025-04-15')
 
 <template>
   <MiniCalendar
-    :value="value"
-    @change="value = $event"
+    v-model="value"
     :number-of-days="6"
     default-date="2025-04-13"
     min-date="2025-04-14"
@@ -57,8 +56,8 @@ export const minMax: MantineDemo = {
       const value = ref<string | null>('2025-04-15')
       return () =>
         h(MiniCalendar, {
-          value: value.value,
-          onChange: (date: string) => (value.value = date),
+          modelValue: value.value,
+          'onUpdate:modelValue': (date: string | null) => (value.value = date),
           numberOfDays: 6,
           defaultDate: '2025-04-13',
           minDate: '2025-04-14',

--- a/apps/mantine.dev/src/demos/dates/TimeGrid/index.ts
+++ b/apps/mantine.dev/src/demos/dates/TimeGrid/index.ts
@@ -22,8 +22,8 @@ const UsageDemo = defineComponent({
     return () =>
       h(TimeGrid, {
         data,
-        value: value.value,
-        onChange: (v: string | null) => (value.value = v ?? undefined),
+        modelValue: value.value,
+        'onUpdate:modelValue': (v: string | null) => (value.value = v ?? undefined),
       })
   },
 })

--- a/apps/mantine.dev/src/demos/hooks/use-selection/use-selection.demo.usage.ts
+++ b/apps/mantine.dev/src/demos/hooks/use-selection/use-selection.demo.usage.ts
@@ -61,8 +61,8 @@ const [selection, handlers] = useSelection({
             aria-label="Select row"
             :checked="selection.value.includes(element.position)"
             @change="
-              (event) => {
-                if (event.target.checked) {
+              (checked) => {
+                if (checked) {
                   handlers.select(element.position)
                 } else {
                   handlers.deselect(element.position)
@@ -110,8 +110,7 @@ const Demo = defineComponent({
               h(Checkbox, {
                 'aria-label': 'Select row',
                 checked: isSelected,
-                onChange: (event: Event) => {
-                  const checked = (event.target as HTMLInputElement).checked
+                onChange: (checked: boolean) => {
                   if (checked) {
                     handlers.select(element.position)
                   } else {

--- a/apps/mantine.dev/src/pages/core/angle-slider.mdx
+++ b/apps/mantine.dev/src/pages/core/angle-slider.mdx
@@ -23,7 +23,7 @@ const value = ref(180)
 </script>
 
 <template>
-  <AngleSlider :value="value" @change="(v) => (value = v)" />
+  <AngleSlider v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/autocomplete.mdx
+++ b/apps/mantine.dev/src/pages/core/autocomplete.mdx
@@ -31,7 +31,7 @@ You can change the position with the `loadingPosition` prop to `'left'` or `'rig
 ## Controlled
 
 The `Autocomplete` value must be a string; other types are not supported.
-The `onChange` function is called with a string value as a single argument.
+Use `v-model` to control the value:
 
 ```vue
 <script setup lang="ts">
@@ -42,7 +42,7 @@ const value = ref('')
 </script>
 
 <template>
-  <Autocomplete :data="[]" :value="value" @change="(v) => (value = v)" />
+  <Autocomplete v-model="value" :data="[]" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/checkbox.mdx
+++ b/apps/mantine.dev/src/pages/core/checkbox.mdx
@@ -10,7 +10,7 @@ export default Layout(MDX_DATA.Checkbox)
 
 ## Controlled state
 
-Use `checked` and `@change` to control `Checkbox` state:
+Use `v-model` to control `Checkbox` state:
 
 ```vue
 <script setup lang="ts">
@@ -21,7 +21,7 @@ const checked = ref(false)
 </script>
 
 <template>
-  <Checkbox :checked="checked" @change="(e) => (checked = e.target.checked)" />
+  <Checkbox v-model="checked" />
 </template>
 ```
 
@@ -140,10 +140,9 @@ You can add any number of custom sizes with [data-size](/styles/data-attributes/
 
 ## Checkbox.Group
 
-`Checkbox.Group` manages the state of multiple checkboxes. It accepts `value` and `@change`
-props which control the state of checkboxes inside the group. The `value` prop should be an
-array of strings, where each string is the value of a checkbox.
-The `@change` handler receives the new value as an array of strings.
+`Checkbox.Group` manages the state of multiple checkboxes with `v-model`. The model is an
+array of strings, where each string is the value of a checkbox. The `@change` handler also
+receives the new array value.
 
 ```vue
 <script setup lang="ts">
@@ -154,7 +153,7 @@ const value = ref<string[]>([])
 </script>
 
 <template>
-  <CheckboxGroup :value="value" @change="value = $event">
+  <CheckboxGroup v-model="value">
     <Checkbox value="react" label="React" />
     <Checkbox value="svelte" label="Svelte" />
   </CheckboxGroup>

--- a/apps/mantine.dev/src/pages/core/chip.mdx
+++ b/apps/mantine.dev/src/pages/core/chip.mdx
@@ -19,7 +19,7 @@ const checked = ref(false)
 </script>
 
 <template>
-  <Chip :checked="checked" @change="checked = !checked">My chip</Chip>
+  <Chip v-model="checked">My chip</Chip>
 </template>
 ```
 
@@ -63,7 +63,7 @@ const multiple = ref(['react'])
 
 <template>
   <!-- Single selection -->
-  <ChipGroup :multiple="false" :value="single" @change="single = $event">
+  <ChipGroup v-model="single" :multiple="false">
     <Chip value="react">React</Chip>
     <Chip value="ng">Angular</Chip>
     <Chip value="svelte">Svelte</Chip>
@@ -71,7 +71,7 @@ const multiple = ref(['react'])
   </ChipGroup>
 
   <!-- Multiple selection -->
-  <ChipGroup multiple :value="multiple" @change="multiple = $event">
+  <ChipGroup v-model="multiple" multiple>
     <Chip value="react">React</Chip>
     <Chip value="ng">Angular</Chip>
     <Chip value="svelte">Svelte</Chip>

--- a/apps/mantine.dev/src/pages/core/multi-select.mdx
+++ b/apps/mantine.dev/src/pages/core/multi-select.mdx
@@ -23,7 +23,7 @@ You can change the position with the `loadingPosition` prop to `'left'` or `'rig
 ## Controlled
 
 The `MultiSelect` value must be an array of strings; other types are not supported.
-The `onChange` function is called with an array of strings as a single argument.
+Use `v-model` to control the value:
 
 ```vue
 <script setup lang="ts">
@@ -34,7 +34,7 @@ const value = ref<string[]>([])
 </script>
 
 <template>
-  <MultiSelect :data="[]" :value="value" @change="(v) => (value = v)" />
+  <MultiSelect v-model="value" :data="[]" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/number-input.mdx
+++ b/apps/mantine.dev/src/pages/core/number-input.mdx
@@ -28,7 +28,7 @@ const value = ref<string | number>('')
 </script>
 
 <template>
-  <NumberInput :value="value" @change="(v) => (value = v)" />
+  <NumberInput v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/password-input.mdx
+++ b/apps/mantine.dev/src/pages/core/password-input.mdx
@@ -28,7 +28,7 @@ const value = ref('')
 </script>
 
 <template>
-  <PasswordInput :value="value" @change="(event) => (value = event.currentTarget.value)" />
+  <PasswordInput v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/pin-input.mdx
+++ b/apps/mantine.dev/src/pages/core/pin-input.mdx
@@ -19,7 +19,7 @@ const value = ref('')
 </script>
 
 <template>
-  <PinInput :value="value" @change="(v) => (value = v)" />
+  <PinInput v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/radio.mdx
+++ b/apps/mantine.dev/src/pages/core/radio.mdx
@@ -19,7 +19,7 @@ const checked = ref(false)
 </script>
 
 <template>
-  <Radio :checked="checked" @change="(event) => (checked = event.currentTarget.checked)" />
+  <Radio v-model="checked" />
 </template>
 ```
 
@@ -117,8 +117,7 @@ const value = ref('react')
 
 <template>
   <Radio.Group
-    :value="value"
-    @change="(v) => (value = v)"
+    v-model="value"
     name="favoriteFramework"
     label="Select your favorite framework/library"
     description="This is anonymous"

--- a/apps/mantine.dev/src/pages/core/range-slider.mdx
+++ b/apps/mantine.dev/src/pages/core/range-slider.mdx
@@ -19,7 +19,7 @@ const value = ref<[number, number]>([20, 80])
 </script>
 
 <template>
-  <RangeSlider :value="value" @change="(v) => (value = v)" />
+  <RangeSlider v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/rating.mdx
+++ b/apps/mantine.dev/src/pages/core/rating.mdx
@@ -19,7 +19,7 @@ const value = ref(0)
 </script>
 
 <template>
-  <Rating :value="value" @change="(v) => (value = v)" />
+  <Rating v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/slider.mdx
+++ b/apps/mantine.dev/src/pages/core/slider.mdx
@@ -19,7 +19,7 @@ const value = ref(40)
 </script>
 
 <template>
-  <Slider :value="value" @change="(v) => (value = v)" />
+  <Slider v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/switch.mdx
+++ b/apps/mantine.dev/src/pages/core/switch.mdx
@@ -19,7 +19,7 @@ const checked = ref(false)
 </script>
 
 <template>
-  <Switch v-model:checked="checked" />
+  <Switch v-model="checked" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/text-input.mdx
+++ b/apps/mantine.dev/src/pages/core/text-input.mdx
@@ -28,7 +28,7 @@ const value = ref('')
 </script>
 
 <template>
-  <TextInput :value="value" @change="(event) => (value = event.currentTarget.value)" />
+  <TextInput v-model="value" />
 </template>
 ```
 

--- a/apps/mantine.dev/src/pages/core/textarea.mdx
+++ b/apps/mantine.dev/src/pages/core/textarea.mdx
@@ -28,7 +28,7 @@ const value = ref('')
 </script>
 
 <template>
-  <Textarea :value="value" @change="(event) => (value = event.currentTarget.value)" />
+  <Textarea v-model="value" />
 </template>
 ```
 

--- a/apps/showcase/src/sections/DatesSection.vue
+++ b/apps/showcase/src/sections/DatesSection.vue
@@ -14,12 +14,10 @@ import {
 } from '@mantine-vue/dates'
 import DemoCard from '../components/DemoCard.vue'
 
-// Mantine dates components are controlled via `:value` + `@change`
-// (they use useUncontrolled internally), not v-model.
 const date = ref<string | null>('2026-07-13')
 const dateRange = ref<[string | null, string | null]>(['2026-07-10', '2026-07-16'])
 const inlineDate = ref<string | null>('2026-07-13')
-const dateTime = ref<string | null>('2026-07-13 09:30')
+const dateTime = ref<Date | null>(new Date('2026-07-13T09:30:00'))
 const month = ref<string | null>('2026-07-01')
 const year = ref<string | null>('2026-01-01')
 const time = ref('09:30')
@@ -35,13 +33,12 @@ const miniDate = ref<string | null>('2026-07-13')
       pkg="dates"
     >
       <DateInput
-        :value="date"
+        v-model="date"
         label="Event date"
         placeholder="Pick a date"
         valueFormat="DD MMM YYYY"
         clearable
         style="max-width: 340px"
-        @change="date = $event"
       />
     </DemoCard>
 
@@ -51,37 +48,29 @@ const miniDate = ref<string | null>('2026-07-13')
       pkg="dates"
     >
       <Stack gap="sm" style="max-width: 340px">
+        <DatePickerInput v-model="date" label="Single date" placeholder="Pick date" clearable />
         <DatePickerInput
-          :value="date"
-          label="Single date"
-          placeholder="Pick date"
-          clearable
-          @change="date = $event"
-        />
-        <DatePickerInput
-          :value="dateRange"
+          v-model="dateRange"
           type="range"
           label="Date range"
           placeholder="Pick date range"
           clearable
-          @change="dateRange = $event"
         />
       </Stack>
     </DemoCard>
 
     <DemoCard name="DatePicker" description="Inline calendar for selecting dates." pkg="dates">
-      <DatePicker :value="inlineDate" @change="inlineDate = $event" />
+      <DatePicker v-model="inlineDate" />
     </DemoCard>
 
     <DemoCard name="DateTimePicker" description="Pick a date together with a time." pkg="dates">
       <DateTimePicker
-        :value="dateTime"
+        v-model="dateTime"
         label="Appointment"
         placeholder="Pick date and time"
         valueFormat="DD MMM YYYY hh:mm A"
         clearable
         style="max-width: 340px"
-        @change="dateTime = $event"
       />
     </DemoCard>
 
@@ -92,19 +81,12 @@ const miniDate = ref<string | null>('2026-07-13')
     >
       <Stack gap="sm" style="max-width: 340px">
         <MonthPickerInput
-          :value="month"
+          v-model="month"
           label="Billing month"
           placeholder="Pick month"
           clearable
-          @change="month = $event"
         />
-        <YearPickerInput
-          :value="year"
-          label="Fiscal year"
-          placeholder="Pick year"
-          clearable
-          @change="year = $event"
-        />
+        <YearPickerInput v-model="year" label="Fiscal year" placeholder="Pick year" clearable />
       </Stack>
     </DemoCard>
 
@@ -114,24 +96,14 @@ const miniDate = ref<string | null>('2026-07-13')
       pkg="dates"
     >
       <Stack gap="sm" style="max-width: 340px">
-        <TimeInput
-          :value="time"
-          label="Start time"
-          @change="time = ($event.currentTarget as HTMLInputElement).value"
-        />
-        <TimePicker
-          :value="preciseTime"
-          label="Precise time"
-          withDropdown
-          :withSeconds="true"
-          @change="preciseTime = $event"
-        />
+        <TimeInput v-model="time" label="Start time" />
+        <TimePicker v-model="preciseTime" label="Precise time" withDropdown :withSeconds="true" />
       </Stack>
     </DemoCard>
 
     <DemoCard name="MiniCalendar" description="Compact horizontal date strip." pkg="dates">
       <Stack gap="xs">
-        <MiniCalendar :value="miniDate" :numberOfDays="7" @change="miniDate = $event" />
+        <MiniCalendar v-model="miniDate" :numberOfDays="7" />
         <Text size="sm" c="dimmed">Selected: {{ miniDate ?? 'none' }}</Text>
       </Stack>
     </DemoCard>

--- a/apps/showcase/src/sections/InputsSection.vue
+++ b/apps/showcase/src/sections/InputsSection.vue
@@ -348,7 +348,7 @@ const treeData = [
 
     <DemoCard name="AngleSlider" description="Circular control for selecting an angle.">
       <Group align="center" gap="lg">
-        <AngleSlider :value="angle" :size="80" :thumbSize="8" @change="angle = $event" />
+        <AngleSlider v-model="angle" :size="80" :thumbSize="8" />
         <Text size="sm" c="dimmed">{{ angle }}°</Text>
       </Group>
     </DemoCard>

--- a/apps/showcase/src/sections/InputsSection.vue
+++ b/apps/showcase/src/sections/InputsSection.vue
@@ -180,16 +180,11 @@ const treeData = [
 
     <DemoCard name="Checkbox" description="Boolean control, individually or grouped.">
       <Stack gap="md">
-        <Checkbox
-          :checked="terms"
-          label="I accept the terms and conditions"
-          @change="terms = ($event.target as HTMLInputElement).checked"
-        />
+        <Checkbox v-model="terms" label="I accept the terms and conditions" />
         <CheckboxGroup
-          :value="permissions"
+          v-model="permissions"
           label="Permissions"
           description="Select all that apply"
-          @change="permissions = $event"
         >
           <Group mt="xs">
             <Checkbox value="read" label="Read" />
@@ -201,12 +196,7 @@ const treeData = [
     </DemoCard>
 
     <DemoCard name="Radio" description="Single choice from a set of options.">
-      <Radio.Group
-        :value="shipping"
-        label="Shipping method"
-        withAsterisk
-        @change="shipping = $event"
-      >
+      <Radio.Group v-model="shipping" label="Shipping method" withAsterisk>
         <Stack gap="xs" mt="xs">
           <Radio value="standard" label="Standard — 5 business days" />
           <Radio value="express" label="Express — 2 business days" />
@@ -223,7 +213,7 @@ const treeData = [
     </DemoCard>
 
     <DemoCard name="Chip" description="Compact selectable pill, single or multi-select group.">
-      <ChipGroup :value="size" multiple @change="size = $event">
+      <ChipGroup v-model="size" multiple>
         <Group>
           <Chip value="sm">Small</Chip>
           <Chip value="md">Medium</Chip>
@@ -234,11 +224,10 @@ const treeData = [
 
     <DemoCard name="NativeSelect" description="Native HTML select element, Mantine-styled.">
       <NativeSelect
-        :value="nativeFramework"
+        v-model="nativeFramework"
         label="Framework"
         :data="frameworks"
         style="max-width: 340px"
-        @change="nativeFramework = ($event.target as HTMLSelectElement).value"
       />
     </DemoCard>
 

--- a/packages/@mantine-vue/core/src/components/AngleSlider/AngleSlider.ts
+++ b/packages/@mantine-vue/core/src/components/AngleSlider/AngleSlider.ts
@@ -23,6 +23,7 @@ export interface AngleSliderMark {
 
 export interface AngleSliderProps {
   step?: number
+  modelValue?: number
   value?: number
   defaultValue?: number
   onChange?: (value: number) => void
@@ -64,6 +65,7 @@ export const AngleSlider = withBoxProps(
     inheritAttrs: false,
     props: {
       step: { type: Number, default: undefined },
+      modelValue: { type: Number, default: undefined },
       value: { type: Number, default: undefined },
       defaultValue: { type: Number, default: undefined },
       onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
@@ -84,14 +86,18 @@ export const AngleSlider = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(rawProps, { attrs }) {
+    emits: ['update:modelValue', 'change'],
+    setup(rawProps, { attrs, emit }) {
       const props = useProps('AngleSlider', defaultProps, rawProps)
       const rootRef = ref<HTMLDivElement | null>(null)
       const [value, setValue] = useUncontrolled<number>({
-        value: () => props.value,
+        value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
         defaultValue: props.defaultValue,
         finalValue: 0,
-        onChange: props.onChange,
+        onChange: (value) => {
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
       })
 
       const update = (nextValue: number) => {

--- a/packages/@mantine-vue/core/src/components/Autocomplete/Autocomplete.ts
+++ b/packages/@mantine-vue/core/src/components/Autocomplete/Autocomplete.ts
@@ -90,6 +90,7 @@ export const Autocomplete = defineComponent({
   },
   emits: {
     'update:modelValue': (value: string) => typeof value === 'string',
+    change: (value: string) => typeof value === 'string',
   },
   setup(props, { attrs, emit, slots }) {
     const internal = ref(props.defaultValue)
@@ -97,8 +98,8 @@ export const Autocomplete = defineComponent({
     const controlled = () => props.modelValue !== undefined || props.value !== undefined
     const change = (value: string) => {
       if (!controlled()) internal.value = value
-      props.onChange?.(value)
       emit('update:modelValue', value)
+      emit('change', value)
       combobox.resetSelectedOption()
     }
     const parsed = computed(() => getParsedComboboxData(props.data))

--- a/packages/@mantine-vue/core/src/components/Cascader/Cascader.ts
+++ b/packages/@mantine-vue/core/src/components/Cascader/Cascader.ts
@@ -185,11 +185,17 @@ export const Cascader = defineComponent({
     styles: [Object, Function],
     unstyled: Boolean,
   },
-  emits: ['update:modelValue', 'update:searchValue'],
+  emits: ['update:modelValue', 'update:searchValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const id = useId((attrs as any).id)
     const internalValue = ref<string[] | null>(props.defaultValue ?? null)
-    const currentValue = computed(() => props.modelValue ?? props.value ?? internalValue.value)
+    const currentValue = computed(() =>
+      props.modelValue !== undefined
+        ? props.modelValue
+        : props.value !== undefined
+          ? props.value
+          : internalValue.value,
+    )
     const pathOptions = computed(() => getCascaderPathOptions(props.data, currentValue.value))
     const separatorString = computed(() =>
       typeof props.separator === 'string' || typeof props.separator === 'number'
@@ -232,8 +238,9 @@ export const Cascader = defineComponent({
 
     const setValue = (value: string[] | null) => {
       if (props.modelValue === undefined && props.value === undefined) internalValue.value = value
-      props.onChange?.(value, getCascaderPathOptions(props.data, value))
+      const selectedOptions = getCascaderPathOptions(props.data, value)
       emit('update:modelValue', value)
+      emit('change', value, selectedOptions)
     }
 
     const resetActivePath = () => {

--- a/packages/@mantine-vue/core/src/components/Checkbox/Checkbox.ts
+++ b/packages/@mantine-vue/core/src/components/Checkbox/Checkbox.ts
@@ -1,5 +1,5 @@
 import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
-import { useId, assignRef } from '@mantine-vue/hooks'
+import { useId, assignRef, useUncontrolled } from '@mantine-vue/hooks'
 import {
   withBoxProps,
   Box,
@@ -96,7 +96,10 @@ const CheckboxBase = defineComponent({
     iconColor: { type: String, default: undefined },
     autoContrast: { type: Boolean, default: undefined },
     withErrorStyles: { type: Boolean, default: true },
+    modelValue: { type: Boolean, default: undefined },
     checked: { type: Boolean, default: undefined },
+    defaultChecked: { type: Boolean, default: undefined },
+    onChange: { type: Function as PropType<(checked: boolean) => void>, default: undefined },
     disabled: { type: Boolean, default: false },
     readOnly: { type: Boolean, default: false },
     variant: { type: String as PropType<CheckboxVariant>, default: 'filled' },
@@ -106,9 +109,20 @@ const CheckboxBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'update:checked', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const uuid = useId(props.id)
     const groupContext = useCheckboxGroupContext()
+    const [localChecked, setLocalChecked] = useUncontrolled<boolean>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.checked),
+      defaultValue: props.defaultChecked,
+      finalValue: false,
+      onChange: (checked) => {
+        emit('update:modelValue', checked)
+        emit('update:checked', checked)
+        emit('change', checked)
+      },
+    })
     const getStyles = useStyles({
       name: 'Checkbox',
       props,
@@ -135,7 +149,7 @@ const CheckboxBase = defineComponent({
       const iconSlotProps = { indeterminate: props.indeterminate, ...iconStyles }
       const Icon = props.icon || CheckboxIcon
       const value = String(attrs.value ?? '')
-      const checked = groupContext ? groupContext.value.includes(value) : props.checked
+      const checked = groupContext ? groupContext.value.includes(value) : localChecked.value
       const disabled = groupContext?.isDisabled?.(value) || props.disabled
       const size = groupContext?.size ?? props.size
 
@@ -178,7 +192,7 @@ const CheckboxBase = defineComponent({
               variant: props.variant,
               onClick: (event: MouseEvent) => {
                 callHandler(attrs.onClick, event)
-                if (props.readOnly && checked === undefined) {
+                if (props.readOnly) {
                   event.preventDefault()
                 }
               },
@@ -186,8 +200,9 @@ const CheckboxBase = defineComponent({
                 if (props.readOnly) {
                   return
                 }
-                callHandler(attrs.onChange, event)
+                const nextChecked = (event.currentTarget as HTMLInputElement).checked
                 groupContext?.onChange(event)
+                setLocalChecked(nextChecked)
               },
             }),
             slots.icon

--- a/packages/@mantine-vue/core/src/components/Checkbox/CheckboxCard/CheckboxCard.ts
+++ b/packages/@mantine-vue/core/src/components/Checkbox/CheckboxCard/CheckboxCard.ts
@@ -32,6 +32,7 @@ export const CheckboxCard = withBoxProps(
     name: 'CheckboxCard',
     inheritAttrs: false,
     props: {
+      modelValue: { type: Boolean, default: undefined },
       checked: { type: Boolean, default: undefined },
       defaultChecked: { type: Boolean, default: undefined },
       onChange: { type: Function as PropType<(value: boolean) => void>, default: undefined },
@@ -44,18 +45,25 @@ export const CheckboxCard = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(props, { attrs, slots }) {
+    emits: ['update:modelValue', 'update:checked', 'change'],
+    setup(props, { attrs, slots, emit }) {
       const groupContext = useCheckboxGroupContext()
       const [checked, setChecked] = useUncontrolled<boolean>({
         value: () =>
-          typeof props.checked === 'boolean'
-            ? props.checked
-            : groupContext
-              ? groupContext.value.includes(props.value || '')
-              : undefined,
+          typeof props.modelValue === 'boolean'
+            ? props.modelValue
+            : typeof props.checked === 'boolean'
+              ? props.checked
+              : groupContext
+                ? groupContext.value.includes(props.value || '')
+                : undefined,
         defaultValue: props.defaultChecked,
         finalValue: false,
-        onChange: (nextValue) => props.onChange?.(nextValue),
+        onChange: (nextValue) => {
+          emit('update:modelValue', nextValue)
+          emit('update:checked', nextValue)
+          emit('change', nextValue)
+        },
       })
       const getStyles = useStyles({
         name: 'CheckboxCard',

--- a/packages/@mantine-vue/core/src/components/Checkbox/CheckboxGroup/CheckboxGroup.ts
+++ b/packages/@mantine-vue/core/src/components/Checkbox/CheckboxGroup/CheckboxGroup.ts
@@ -39,6 +39,7 @@ export const CheckboxGroup = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<CheckboxGroupSlots>,
   props: {
+    modelValue: { type: Array as PropType<string[] | undefined>, default: undefined },
     value: { type: Array as PropType<string[] | undefined>, default: undefined },
     defaultValue: { type: Array as PropType<string[] | undefined>, default: undefined },
     onChange: { type: Function as PropType<(value: string[]) => void>, default: undefined },
@@ -61,12 +62,16 @@ export const CheckboxGroup = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const [value, setValue] = useUncontrolled<string[]>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: [],
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
 
     const handleChange = (eventOrValue: Event | string) => {

--- a/packages/@mantine-vue/core/src/components/Chip/Chip.ts
+++ b/packages/@mantine-vue/core/src/components/Chip/Chip.ts
@@ -47,14 +47,6 @@ const varsResolver = createVarsResolver<any>(
   },
 )
 
-function callHandler(handler: any, event: Event) {
-  if (Array.isArray(handler)) {
-    handler.forEach((item) => item?.(event))
-  } else {
-    handler?.(event)
-  }
-}
-
 const ChipBase = defineComponent({
   name: 'Chip',
   inheritAttrs: false,
@@ -63,6 +55,7 @@ const ChipBase = defineComponent({
     radius: { type: [String, Number] as PropType<MantineRadius>, default: undefined },
     size: { type: String as PropType<MantineSize>, default: 'sm' },
     type: { type: String as PropType<'radio' | 'checkbox'>, default: 'checkbox' },
+    modelValue: { type: Boolean, default: undefined },
     checked: { type: Boolean, default: undefined },
     defaultChecked: { type: Boolean, default: undefined },
     onChange: { type: Function as PropType<(checked: boolean) => void>, default: undefined },
@@ -83,15 +76,20 @@ const ChipBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(rawProps, { attrs, slots }) {
+  emits: ['update:modelValue', 'update:checked', 'change'],
+  setup(rawProps, { attrs, slots, emit }) {
     const props = useProps('Chip', null, rawProps)
     const groupContext = useChipGroupContext()
     const uuid = useId(props.id)
     const [value, setValue] = useUncontrolled<boolean>({
-      value: () => props.checked,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.checked),
       defaultValue: props.defaultChecked,
       finalValue: false,
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('update:checked', nextValue)
+        emit('change', nextValue)
+      },
     })
     const getStyles = useStyles({
       name: 'Chip',
@@ -116,7 +114,6 @@ const ChipBase = defineComponent({
       const {
         class: _class,
         style: _style,
-        onChange: attrsOnChange,
         value: _attrsValue,
         ...inputAttrs
       } = attrs as Record<string, any>
@@ -150,14 +147,11 @@ const ChipBase = defineComponent({
             disabled: props.disabled,
             value: chipValue,
             onChange: (event: Event) => {
-              callHandler(attrsOnChange, event)
-
+              const nextChecked = (event.currentTarget as HTMLInputElement).checked
               if (groupContext) {
                 groupContext.onChange(event)
-                props.onChange?.((event.currentTarget as HTMLInputElement).checked)
-              } else {
-                setValue((event.currentTarget as HTMLInputElement).checked)
               }
+              setValue(nextChecked)
             },
           }),
           h(

--- a/packages/@mantine-vue/core/src/components/Chip/ChipGroup/ChipGroup.ts
+++ b/packages/@mantine-vue/core/src/components/Chip/ChipGroup/ChipGroup.ts
@@ -19,6 +19,10 @@ export const ChipGroup = defineComponent({
   name: 'ChipGroup',
   props: {
     multiple: { type: Boolean, default: false },
+    modelValue: {
+      type: [String, Array] as PropType<string | string[] | null | undefined>,
+      default: undefined,
+    },
     value: {
       type: [String, Array] as PropType<string | string[] | null | undefined>,
       default: undefined,
@@ -32,12 +36,16 @@ export const ChipGroup = defineComponent({
       default: undefined,
     },
   },
-  setup(props, { slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { slots, emit }) {
     const [value, setValue] = useUncontrolled<ChipGroupValue>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: props.multiple ? [] : null,
-      onChange: (nextValue) => props.onChange?.(nextValue as string | string[]),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
 
     const isChipSelected = (chipValue: string) =>

--- a/packages/@mantine-vue/core/src/components/ColorInput/ColorInput.ts
+++ b/packages/@mantine-vue/core/src/components/ColorInput/ColorInput.ts
@@ -69,7 +69,7 @@ export const ColorInput = defineComponent({
     swatches: Array as PropType<string[]>,
     swatchesPerRow: { type: Number, default: 7 },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const internal = ref(props.defaultValue)
     const current = () => props.modelValue ?? props.value ?? internal.value
@@ -78,8 +78,8 @@ export const ColorInput = defineComponent({
     const lastValid = ref(isColorValid(current()) ? current() : '')
     const setValue = (value: string, end = false) => {
       if (!controlled()) internal.value = value
-      props.onChange?.(value)
       emit('update:modelValue', value)
+      emit('change', value)
       if (isColorValid(value)) {
         lastValid.value = value
         if (end) props.onChangeEnd?.(convertHsvaTo(props.format, parseColor(value)))

--- a/packages/@mantine-vue/core/src/components/ColorPicker/AlphaSlider/AlphaSlider.ts
+++ b/packages/@mantine-vue/core/src/components/ColorPicker/AlphaSlider/AlphaSlider.ts
@@ -6,7 +6,9 @@ export const AlphaSlider = defineComponent({
   name: 'AlphaSlider',
   inheritAttrs: false,
   props: {
-    value: { type: Number, required: true },
+    modelValue: { type: Number, default: undefined },
+    value: { type: Number, default: undefined },
+    defaultValue: { type: Number, default: undefined },
     color: { type: String, required: true },
     onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
     onChangeEnd: { type: Function as PropType<(value: number) => void>, default: undefined },
@@ -15,7 +17,8 @@ export const AlphaSlider = defineComponent({
     size: { type: String, default: 'md' },
     focusable: { type: Boolean, default: true },
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     return () =>
       h(ColorSlider, {
         ...attrs,
@@ -24,7 +27,8 @@ export const AlphaSlider = defineComponent({
         maxValue: 1,
         round: false,
         'data-alpha': '',
-        onChange: (value: number) => props.onChange?.(round(value, 2)),
+        'onUpdate:modelValue': (value: number) => emit('update:modelValue', round(value, 2)),
+        onChange: (value: number) => emit('change', round(value, 2)),
         onChangeEnd: (value: number) => props.onChangeEnd?.(round(value, 2)),
         overlays: [
           {

--- a/packages/@mantine-vue/core/src/components/ColorPicker/ColorPicker.ts
+++ b/packages/@mantine-vue/core/src/components/ColorPicker/ColorPicker.ts
@@ -52,6 +52,7 @@ export const ColorPicker = defineComponent({
   name: 'ColorPicker',
   inheritAttrs: false,
   props: {
+    modelValue: { type: String, default: undefined },
     value: { type: String, default: undefined },
     defaultValue: { type: String, default: undefined },
     onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
@@ -76,13 +77,17 @@ export const ColorPicker = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(rawProps, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(rawProps, { attrs, emit }) {
     const props = useProps('ColorPicker', defaults as any, rawProps) as any
     const [current, setCurrent, controlled] = useUncontrolled<string>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: '#FFFFFF',
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const parsed = ref<HsvaColor>(parseColor(current.value))
     let scrubbing = false

--- a/packages/@mantine-vue/core/src/components/ColorPicker/ColorSlider/ColorSlider.ts
+++ b/packages/@mantine-vue/core/src/components/ColorPicker/ColorSlider/ColorSlider.ts
@@ -1,5 +1,5 @@
 import { defineComponent, h, ref, watch, type PropType } from 'vue'
-import { clampUseMovePosition, useMove } from '@mantine-vue/hooks'
+import { clampUseMovePosition, useMove, useUncontrolled } from '@mantine-vue/hooks'
 import { Box, useMantineTheme, useStyles } from '../../../core'
 import { useColorPickerContext } from '../ColorPicker.context'
 import { Thumb } from '../Thumb/Thumb'
@@ -9,7 +9,9 @@ export const ColorSlider = defineComponent({
   name: 'ColorSlider',
   inheritAttrs: false,
   props: {
-    value: { type: Number, required: true },
+    modelValue: { type: Number, default: undefined },
+    value: { type: Number, default: undefined },
+    defaultValue: { type: Number, default: undefined },
     onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
     onChangeEnd: { type: Function as PropType<(value: number) => void>, default: undefined },
     onScrubStart: { type: Function as PropType<() => void>, default: undefined },
@@ -25,10 +27,20 @@ export const ColorSlider = defineComponent({
     styles: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const ctx = useColorPickerContext()
     const theme = useMantineTheme()
-    const position = ref({ x: props.value / props.maxValue, y: 0 })
+    const [value, setValue] = useUncontrolled<number>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+      defaultValue: props.defaultValue,
+      finalValue: 0,
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
+    const position = ref({ x: value.value / props.maxValue, y: 0 })
     const positionRef = ref(position.value)
     const ownStyles = useStyles({
       name: props.__staticSelector,
@@ -47,7 +59,7 @@ export const ColorSlider = defineComponent({
       ({ x, y }) => {
         positionRef.value = { x, y }
         position.value = { x, y: 0 }
-        props.onChange?.(changeValue(x))
+        setValue(changeValue(x))
       },
       {
         onScrubStart: props.onScrubStart,
@@ -57,10 +69,7 @@ export const ColorSlider = defineComponent({
         },
       },
     )
-    watch(
-      () => props.value,
-      (value) => (position.value = { x: value / props.maxValue, y: 0 }),
-    )
+    watch(value, (value) => (position.value = { x: value / props.maxValue, y: 0 }))
     const keydown = (event: KeyboardEvent) => {
       if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
       event.preventDefault()
@@ -69,7 +78,7 @@ export const ColorSlider = defineComponent({
         y: 0,
       })
       const value = changeValue(next.x)
-      props.onChange?.(value)
+      setValue(value)
       props.onChangeEnd?.(value)
     }
     return () =>
@@ -80,7 +89,7 @@ export const ColorSlider = defineComponent({
           ref: (node: any) => move.ref(node?.$el ?? node),
           ...getStyles('slider', { className: attrs.class, style: attrs.style }),
           role: 'slider',
-          'aria-valuenow': props.value,
+          'aria-valuenow': value.value,
           'aria-valuemax': props.maxValue,
           'aria-valuemin': 0,
           tabindex: props.focusable ? 0 : -1,

--- a/packages/@mantine-vue/core/src/components/ColorPicker/HueSlider/HueSlider.ts
+++ b/packages/@mantine-vue/core/src/components/ColorPicker/HueSlider/HueSlider.ts
@@ -5,7 +5,9 @@ export const HueSlider = defineComponent({
   name: 'HueSlider',
   inheritAttrs: false,
   props: {
-    value: { type: Number, required: true },
+    modelValue: { type: Number, default: undefined },
+    value: { type: Number, default: undefined },
+    defaultValue: { type: Number, default: undefined },
     onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
     onChangeEnd: { type: Function as PropType<(value: number) => void>, default: undefined },
     onScrubStart: { type: Function as PropType<() => void>, default: undefined },
@@ -13,14 +15,17 @@ export const HueSlider = defineComponent({
     size: { type: String, default: 'md' },
     focusable: { type: Boolean, default: true },
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     return () =>
       h(ColorSlider, {
         ...attrs,
         ...props,
+        'onUpdate:modelValue': (value: number) => emit('update:modelValue', value),
+        onChange: (value: number) => emit('change', value),
         __staticSelector: 'HueSlider',
         maxValue: 360,
-        thumbColor: `hsl(${props.value}, 100%, 50%)`,
+        thumbColor: `hsl(${props.modelValue ?? props.value ?? props.defaultValue ?? 0}, 100%, 50%)`,
         round: true,
         'data-hue': '',
         overlays: [

--- a/packages/@mantine-vue/core/src/components/Combobox/Combobox.ts
+++ b/packages/@mantine-vue/core/src/components/Combobox/Combobox.ts
@@ -289,11 +289,15 @@ export const ComboboxSearch = defineComponent({
   name: 'ComboboxSearch',
   inheritAttrs: false,
   props: {
+    modelValue: { type: String, default: undefined },
+    value: { type: String, default: undefined },
+    defaultValue: { type: String, default: undefined },
     withAriaAttributes: { type: Boolean, default: true },
     withKeyboardNavigation: { type: Boolean, default: true },
     size: String,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const ctx = useComboboxContext()
     const targetProps = useComboboxTargetProps({
       targetType: 'input',
@@ -307,6 +311,11 @@ export const ComboboxSearch = defineComponent({
     return () =>
       h(Input, {
         ...attrs,
+        modelValue: props.modelValue,
+        value: props.value,
+        defaultValue: props.defaultValue,
+        'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+        onChange: (value: string) => emit('change', value),
         ...targetProps,
         ref: (node: any) => {
           const element = node?.$el?.querySelector?.('input') ?? node?.$el ?? node

--- a/packages/@mantine-vue/core/src/components/ComboboxPopover/ComboboxPopover.ts
+++ b/packages/@mantine-vue/core/src/components/ComboboxPopover/ComboboxPopover.ts
@@ -42,6 +42,9 @@ export interface ComboboxPopoverProps<
   multiple?: Multiple
 
   /** Controlled component value */
+  modelValue?: ComboboxPopoverValue<Multiple, Value>
+
+  /** Legacy controlled component value */
   value?: ComboboxPopoverValue<Multiple, Value>
 
   /** Uncontrolled component default value */
@@ -225,6 +228,7 @@ export const ComboboxPopoverBase = defineComponent({
   slots: Object as SlotsType<ComboboxPopoverSlots>,
   props: {
     multiple: { type: Boolean, default: undefined },
+    modelValue: { type: null as unknown as PropType<any>, default: undefined },
     value: { type: null as unknown as PropType<any>, default: undefined },
     defaultValue: { type: null as unknown as PropType<any>, default: undefined },
     onChange: { type: Function as PropType<(value: any) => void>, default: undefined },
@@ -266,7 +270,8 @@ export const ComboboxPopoverBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(rawProps, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(rawProps, { attrs, slots, emit }) {
     const props = new Proxy(rawProps, {
       get(target, key: string) {
         const value = (target as any)[key]
@@ -278,10 +283,13 @@ export const ComboboxPopoverBase = defineComponent({
     const optionsLockup = computed(() => getOptionsLockup(parsedData.value))
 
     const [_value, setValue] = useUncontrolled<any>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: props.multiple ? [] : null,
-      onChange: (val) => props.onChange?.(val),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
 
     const [_searchValue, setSearchValue] = useUncontrolled<string>({

--- a/packages/@mantine-vue/core/src/components/FileButton/FileButton.ts
+++ b/packages/@mantine-vue/core/src/components/FileButton/FileButton.ts
@@ -5,9 +5,13 @@ export const FileButton = defineComponent({
   name: 'FileButton',
   inheritAttrs: false,
   props: {
+    modelValue: {
+      type: [Object, Array, null] as PropType<File | File[] | null | undefined>,
+      default: undefined,
+    },
     onChange: {
       type: Function as PropType<(payload: File | File[] | null) => void>,
-      required: true,
+      default: undefined,
     },
     multiple: { type: Boolean, default: false },
     accept: { type: String, default: undefined },
@@ -22,7 +26,8 @@ export const FileButton = defineComponent({
     inputProps: { type: Object as PropType<Record<string, any>>, default: undefined },
     inputRef: { type: [Object, Function] as PropType<any>, default: undefined },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const inputRef = ref<HTMLInputElement | null>(null)
     const reset = () => {
       if (inputRef.value) {
@@ -56,11 +61,15 @@ export const FileButton = defineComponent({
           const files = (event.currentTarget as HTMLInputElement).files
 
           if (files === null) {
-            props.onChange(props.multiple ? [] : null)
+            const nextValue = props.multiple ? [] : null
+            emit('update:modelValue', nextValue)
+            emit('change', nextValue)
             return
           }
 
-          props.onChange(props.multiple ? Array.from(files) : files[0] || null)
+          const nextValue = props.multiple ? Array.from(files) : files[0] || null
+          emit('update:modelValue', nextValue)
+          emit('change', nextValue)
         },
       }),
       slots.default?.({ onClick, ...attrs }),

--- a/packages/@mantine-vue/core/src/components/FileInput/FileInput.ts
+++ b/packages/@mantine-vue/core/src/components/FileInput/FileInput.ts
@@ -40,6 +40,10 @@ export const FileInput = defineComponent({
   slots: Object as SlotsType<FileInputSlots>,
   props: {
     component: { type: String, default: 'button' },
+    modelValue: {
+      type: [Object, Array, null] as PropType<File | File[] | null | undefined>,
+      default: undefined,
+    },
     onChange: {
       type: Function as PropType<(payload: File | File[] | null) => void>,
       default: undefined,
@@ -93,13 +97,17 @@ export const FileInput = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const resetRef = ref<(() => void) | null>(null)
     const [value, setValue] = useUncontrolled<File | File[] | null>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: props.multiple ? [] : null,
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
     const hasValue = computed(() =>
       Array.isArray(value.value) ? value.value.length !== 0 : value.value !== null,

--- a/packages/@mantine-vue/core/src/components/Input/Input.ts
+++ b/packages/@mantine-vue/core/src/components/Input/Input.ts
@@ -1,5 +1,5 @@
 import { reactive, defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
-import { assignRef } from '@mantine-vue/hooks'
+import { assignRef, useUncontrolled } from '@mantine-vue/hooks'
 import {
   withBoxProps,
   Box,
@@ -78,6 +78,10 @@ const InputBase = defineComponent({
   slots: Object as SlotsType<InputSlots>,
   props: {
     component: { type: [String, Object, Function] as PropType<any>, default: 'input' },
+    modelValue: { type: null as unknown as PropType<any>, default: undefined },
+    value: { type: null as unknown as PropType<any>, default: undefined },
+    defaultValue: { type: null as unknown as PropType<any>, default: undefined },
+    onChange: { type: Function as PropType<(value: any) => void>, default: undefined },
     __staticSelector: { type: String, default: undefined },
     __stylesApiProps: { type: Object as PropType<Record<string, any>>, default: undefined },
     leftSection: { type: null as unknown as PropType<MantineNode>, default: undefined },
@@ -131,7 +135,26 @@ const InputBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
+    const [value, setValue] = useUncontrolled<any>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+      defaultValue: props.defaultValue,
+      finalValue: undefined,
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
+
+    const callHandler = (handler: unknown, event: Event) => {
+      if (Array.isArray(handler)) {
+        handler.forEach((item) => item?.(event))
+      } else if (typeof handler === 'function') {
+        handler(event)
+      }
+    }
+
     const wrapperCtx = useInputWrapperContext()
     const stylesCtx = reactive<InputStylesCtx>({
       offsetBottom: false,
@@ -232,6 +255,19 @@ const InputBase = defineComponent({
             {
               ...attrs,
               ...ariaAttributes,
+              value:
+                props.component === 'button' || props.component === 'div' ? undefined : value.value,
+              onInput: (event: Event) => {
+                callHandler(attrs.onInput, event)
+                if (props.component !== 'select') {
+                  setValue((event.currentTarget as HTMLInputElement).value)
+                }
+              },
+              onChange: (event: Event) => {
+                if (props.component === 'select') {
+                  setValue((event.currentTarget as HTMLSelectElement).value)
+                }
+              },
               component: props.component,
               required: props.required,
               disabled: props.disabled,

--- a/packages/@mantine-vue/core/src/components/InputBase/InputBase.ts
+++ b/packages/@mantine-vue/core/src/components/InputBase/InputBase.ts
@@ -1,3 +1,4 @@
+import { useUncontrolled } from '@mantine-vue/hooks'
 import { withBoxProps, type MantineRadius, type MantineSize } from '../../core'
 import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
 import { Input } from '../Input'
@@ -28,6 +29,10 @@ export const InputBase = withBoxProps(
     slots: Object as SlotsType<InputBaseSlots>,
     props: {
       component: { type: [String, Object, Function] as PropType<any>, default: 'input' },
+      modelValue: { type: null as unknown as PropType<any>, default: undefined },
+      value: { type: null as unknown as PropType<any>, default: undefined },
+      defaultValue: { type: null as unknown as PropType<any>, default: undefined },
+      onChange: { type: Function as PropType<(value: any) => void>, default: undefined },
       __staticSelector: { type: String, default: 'InputBase' },
       __stylesApiProps: { type: Object as PropType<Record<string, any>>, default: undefined },
       label: { type: null as unknown as PropType<MantineNode>, default: undefined },
@@ -108,7 +113,18 @@ export const InputBase = withBoxProps(
       rootRef: { type: [Object, Function] as PropType<any>, default: undefined },
       mod: { type: [Object, Array] as PropType<any>, default: undefined },
     },
-    setup(props, { attrs, slots }) {
+    emits: ['update:modelValue', 'change'],
+    setup(props, { attrs, slots, emit }) {
+      const [value, setValue] = useUncontrolled<any>({
+        value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+        defaultValue: props.defaultValue,
+        finalValue: undefined,
+        onChange: (nextValue) => {
+          emit('update:modelValue', nextValue)
+          emit('change', nextValue)
+        },
+      })
+
       return () =>
         h(
           Input.Wrapper,
@@ -143,6 +159,8 @@ export const InputBase = withBoxProps(
                 Input,
                 {
                   ...attrs,
+                  modelValue: value.value,
+                  'onUpdate:modelValue': setValue,
                   component: props.component,
                   __staticSelector: props.__staticSelector,
                   __stylesApiProps: props.__stylesApiProps ?? props,

--- a/packages/@mantine-vue/core/src/components/JsonInput/JsonInput.ts
+++ b/packages/@mantine-vue/core/src/components/JsonInput/JsonInput.ts
@@ -16,6 +16,7 @@ export const JsonInput = defineComponent({
   name: 'JsonInput',
   inheritAttrs: false,
   props: {
+    modelValue: { type: String, default: undefined },
     value: { type: String, default: undefined },
     defaultValue: { type: String, default: undefined },
     onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
@@ -33,12 +34,16 @@ export const JsonInput = defineComponent({
       default: undefined,
     },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const [value, setValue] = useUncontrolled<string>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: '',
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
     const valid = ref(validateJson(value.value, props.deserialize))
 

--- a/packages/@mantine-vue/core/src/components/MaskInput/MaskInput.ts
+++ b/packages/@mantine-vue/core/src/components/MaskInput/MaskInput.ts
@@ -16,6 +16,10 @@ import {
 
 export interface MaskInputProps {
   mask: MaskInputMask
+  modelValue?: string
+  value?: string
+  defaultValue?: string
+  onChange?: (value: string) => void
   tokens?: Record<string, RegExp>
   modify?: (
     value: string,
@@ -49,6 +53,10 @@ export const MaskInput = defineComponent({
   inheritAttrs: false,
   props: {
     mask: { type: [String, Array] as PropType<MaskInputMask>, required: true },
+    modelValue: { type: String, default: undefined },
+    value: { type: String, default: undefined },
+    defaultValue: { type: String, default: undefined },
+    onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
     tokens: { type: Object as PropType<Record<string, RegExp>>, default: undefined },
     modify: { type: Function as PropType<MaskInputProps['modify']>, default: undefined },
     separate: { type: Boolean, default: false },
@@ -71,7 +79,8 @@ export const MaskInput = defineComponent({
     },
     resetRef: { type: [Object, Function] as PropType<any>, default: undefined },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const input = ref<HTMLInputElement | null>(null)
     const processed = ref('')
     const rawValue = ref('')
@@ -128,6 +137,8 @@ export const MaskInput = defineComponent({
 
       const complete = isComplete(reprocessed, resolved.slots)
       if (notify) {
+        emit('update:modelValue', nextDisplay)
+        emit('change', nextDisplay)
         props.onChangeRaw?.(resolvedRaw, nextDisplay)
         if (complete && !wasComplete.value) {
           props.onComplete?.(nextDisplay, resolvedRaw)
@@ -147,6 +158,8 @@ export const MaskInput = defineComponent({
       if (input.value) {
         input.value.value = displayValue.value
       }
+      emit('update:modelValue', '')
+      emit('change', '')
       props.onChangeRaw?.('', '')
     }
 
@@ -156,7 +169,7 @@ export const MaskInput = defineComponent({
       (value) => assignRef(value, reset),
     )
     watch(
-      () => (attrs as any).value,
+      () => (props.modelValue !== undefined ? props.modelValue : props.value),
       (value) => {
         if (input.value && value !== undefined && String(value) !== displayValue.value) {
           commit(String(value), undefined, false, String(value))
@@ -174,7 +187,7 @@ export const MaskInput = defineComponent({
         return
       }
 
-      const initial = (attrs as any).value ?? (attrs as any).defaultValue ?? input.value.value
+      const initial = props.modelValue ?? props.value ?? props.defaultValue ?? input.value.value
       if (initial) {
         commit(String(initial), undefined, false, String(initial))
       } else if (props.alwaysShowMask) {
@@ -332,6 +345,7 @@ export const MaskInput = defineComponent({
           type: forwarded.type ?? 'text',
           __staticSelector: 'MaskInput',
           __stylesApiProps: attrs,
+          value: displayValue.value,
           rootRef: attach,
           onInput: handleInput,
           onFocus: handleFocus,

--- a/packages/@mantine-vue/core/src/components/Menu/Menu.ts
+++ b/packages/@mantine-vue/core/src/components/Menu/Menu.ts
@@ -12,6 +12,7 @@ import {
   type SlotsType,
   type VNodeChild,
 } from 'vue'
+import { useUncontrolled } from '@mantine-vue/hooks'
 import {
   Box,
   hasNode,
@@ -414,19 +415,30 @@ export const MenuSearch = defineComponent({
   name: 'MenuSearch',
   inheritAttrs: false,
   props: {
+    modelValue: { type: String, default: undefined },
+    value: { type: String, default: undefined },
+    defaultValue: { type: String, default: undefined },
+    onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
     clearSearchOnClose: { type: Boolean, default: true },
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const ctx = useMenuContext()
+    const [value, setValue] = useUncontrolled<string>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+      defaultValue: props.defaultValue,
+      finalValue: '',
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
     const unregister = ctx.registerSearch()
     ctx.setSearchExitClear(
       props.clearSearchOnClose
         ? () => {
             clearActive(document.querySelector('[data-menu-dropdown]'))
-            ;(attrs as any).onChange?.({
-              currentTarget: { value: '' },
-              target: { value: '' },
-            })
+            setValue('')
           }
         : null,
     )
@@ -452,6 +464,7 @@ export const MenuSearch = defineComponent({
 
       return h(Input, {
         ...forwarded,
+        value: value.value,
         type: 'search',
         'data-autofocus': '',
         'data-mantine-stop-propagation': '',
@@ -469,11 +482,7 @@ export const MenuSearch = defineComponent({
         },
         onInput: (event: Event) => {
           call((attrs as any).onInput, event)
-          call((attrs as any).onChange, event)
-          clearActive((event.currentTarget as HTMLElement).closest('[data-menu-dropdown]'))
-        },
-        onChange: (event: Event) => {
-          call((attrs as any).onChange, event)
+          setValue((event.currentTarget as HTMLInputElement).value)
           clearActive((event.currentTarget as HTMLElement).closest('[data-menu-dropdown]'))
         },
         onKeydown: (event: KeyboardEvent) => {

--- a/packages/@mantine-vue/core/src/components/MultiSelect/MultiSelect.ts
+++ b/packages/@mantine-vue/core/src/components/MultiSelect/MultiSelect.ts
@@ -109,7 +109,7 @@ export const MultiSelect = defineComponent({
     openOnFocus: { type: Boolean, default: true },
     selectFirstOptionOnDropdownOpen: Boolean,
   },
-  emits: ['update:modelValue', 'update:searchValue'],
+  emits: ['update:modelValue', 'update:searchValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const parsed = computed(() => getParsedComboboxData(props.data))
     const lockup = computed(() => getOptionsLockup(parsed.value))
@@ -127,8 +127,8 @@ export const MultiSelect = defineComponent({
     }
     const setValue = (value: Primitive[]) => {
       if (!controlled()) internal.value = value
-      props.onChange?.(value)
       emit('update:modelValue', value)
+      emit('change', value)
     }
     const combobox = useCombobox({
       opened: () => props.dropdownOpened,

--- a/packages/@mantine-vue/core/src/components/NativeSelect/NativeSelect.ts
+++ b/packages/@mantine-vue/core/src/components/NativeSelect/NativeSelect.ts
@@ -26,9 +26,10 @@ export interface NativeSelectProps {
   id?: string
   name?: string
   form?: string
+  modelValue?: string
   value?: string
   defaultValue?: string
-  onChange?: (event: Event) => void
+  onChange?: (value: string) => void
   variant?: 'default' | 'filled' | 'unstyled'
   radius?: string | number
   classNames?: Record<string, string> | ((theme: any, props: any) => Record<string, string>)
@@ -91,9 +92,10 @@ export const NativeSelect = defineComponent({
     id: { type: String, default: undefined },
     name: { type: String, default: undefined },
     form: { type: String, default: undefined },
+    modelValue: { type: String, default: undefined },
     value: { type: String, default: undefined },
     defaultValue: { type: String, default: undefined },
-    onChange: { type: Function as PropType<(event: Event) => void>, default: undefined },
+    onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
     variant: { type: String as PropType<'default' | 'filled' | 'unstyled'>, default: undefined },
     radius: { type: [String, Number] as PropType<MantineRadius>, default: undefined },
     classNames: { type: [Object, Function], default: undefined },
@@ -101,7 +103,8 @@ export const NativeSelect = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(rawProps, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(rawProps, { attrs, slots, emit }) {
     const props = useProps('NativeSelect', defaultProps, rawProps)
 
     return () => {
@@ -131,9 +134,11 @@ export const NativeSelect = defineComponent({
           id: props.id,
           name: props.name,
           form: props.form,
-          ...(props.value !== undefined ? { value: props.value } : null),
-          ...(props.defaultValue !== undefined ? { value: props.defaultValue } : null),
-          onChange: props.onChange,
+          modelValue: props.modelValue,
+          value: props.value,
+          defaultValue: props.defaultValue,
+          'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+          onChange: (value: string) => emit('change', value),
           variant: props.variant,
           radius: props.radius,
           classNames: props.classNames,

--- a/packages/@mantine-vue/core/src/components/NumberInput/NumberInput.ts
+++ b/packages/@mantine-vue/core/src/components/NumberInput/NumberInput.ts
@@ -297,6 +297,10 @@ export const NumberInput = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<NumberInputSlots>,
   props: {
+    modelValue: {
+      type: [String, Number, BigInt] as PropType<NumberInputValue | undefined>,
+      default: undefined,
+    },
     value: {
       type: [String, Number, BigInt] as PropType<NumberInputValue | undefined>,
       default: undefined,
@@ -375,17 +379,24 @@ export const NumberInput = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const inputRef = ref<HTMLInputElement | null>(null)
     const isEditing = ref(false)
     const isBigIntMode = computed(
-      () => typeof props.value === 'bigint' || typeof props.defaultValue === 'bigint',
+      () =>
+        typeof props.modelValue === 'bigint' ||
+        typeof props.value === 'bigint' ||
+        typeof props.defaultValue === 'bigint',
     )
     const [value, setValue] = useUncontrolled<NumberInputValue>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: '',
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
     const getStyles = useStyles({
       name: 'NumberInput',

--- a/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
+++ b/packages/@mantine-vue/core/src/components/PasswordInput/PasswordInput.ts
@@ -51,6 +51,10 @@ export const PasswordInput = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<PasswordInputSlots>,
   props: {
+    modelValue: { type: String, default: undefined },
+    value: { type: String, default: undefined },
+    defaultValue: { type: String, default: undefined },
+    onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
     visibilityToggleIcon: { type: [Object, Function] as PropType<any>, default: undefined },
     visibilityToggleButtonProps: {
       type: Object as PropType<Record<string, any>>,
@@ -104,7 +108,8 @@ export const PasswordInput = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const uuid = useId(props.id)
     const fallbackId = ref(`password-input-${Math.random().toString(36).slice(2)}`)
     const [visible, setVisible] = useUncontrolled<boolean>({
@@ -112,6 +117,15 @@ export const PasswordInput = defineComponent({
       defaultValue: props.defaultVisible,
       finalValue: false,
       onChange: (value) => props.onVisibilityChange?.(value),
+    })
+    const [value, setValue] = useUncontrolled<string>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+      defaultValue: props.defaultValue,
+      finalValue: '',
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
     const getStyles = useStyles({
       name: 'PasswordInput',
@@ -251,6 +265,7 @@ export const PasswordInput = defineComponent({
                   h('input', {
                     ...attrs,
                     ...getStyles('innerInput'),
+                    value: value.value,
                     required: props.required,
                     'data-invalid': props.error || slots.error ? true : undefined,
                     'data-with-left-section':
@@ -260,6 +275,11 @@ export const PasswordInput = defineComponent({
                     'aria-describedby': describedBy,
                     autocomplete: (attrs.autocomplete as any) || 'off',
                     type: visible.value ? 'text' : 'password',
+                    onInput: (event: Event) => {
+                      const handler = attrs.onInput as ((event: Event) => void) | undefined
+                      handler?.(event)
+                      setValue((event.currentTarget as HTMLInputElement).value)
+                    },
                   }),
                 leftSection: slots.leftSection,
                 rightSection: slots.rightSection,

--- a/packages/@mantine-vue/core/src/components/PillsInput/PillsInputField/PillsInputField.ts
+++ b/packages/@mantine-vue/core/src/components/PillsInput/PillsInputField/PillsInputField.ts
@@ -1,5 +1,5 @@
 import { defineComponent, h, type PropType } from 'vue'
-import { assignRef } from '@mantine-vue/hooks'
+import { assignRef, useUncontrolled } from '@mantine-vue/hooks'
 import { withBoxProps, Box, useProps, useStyles } from '../../../core'
 import { useInputWrapperContext } from '../../Input'
 import { usePillsInputContext } from '../PillsInput.context'
@@ -12,6 +12,10 @@ export const PillsInputField = withBoxProps(
     name: 'PillsInputField',
     inheritAttrs: false,
     props: {
+      modelValue: { type: String, default: undefined },
+      value: { type: String, default: undefined },
+      defaultValue: { type: String, default: undefined },
+      onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
       type: { type: String as PropType<'auto' | 'visible' | 'hidden'>, default: 'visible' },
       pointer: { type: Boolean, default: false },
       disabled: { type: Boolean, default: false },
@@ -23,8 +27,18 @@ export const PillsInputField = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(rawProps, { attrs }) {
+    emits: ['update:modelValue', 'change'],
+    setup(rawProps, { attrs, emit }) {
       const props = useProps('PillsInputField', null, rawProps)
+      const [value, setValue] = useUncontrolled<string>({
+        value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
+        defaultValue: props.defaultValue,
+        finalValue: '',
+        onChange: (nextValue) => {
+          emit('update:modelValue', nextValue)
+          emit('change', nextValue)
+        },
+      })
       const context = usePillsInputContext()
       const inputWrapperContext = useInputWrapperContext()
       const getStyles = useStyles({
@@ -45,6 +59,7 @@ export const PillsInputField = withBoxProps(
           ...attrs,
           ...getStyles('field', { className: attrs.class, style: attrs.style as any }),
           component: 'input',
+          value: value.value,
           ref: (node: any) => {
             const input = node?.$el ?? node ?? null
             if (context) {
@@ -59,6 +74,11 @@ export const PillsInputField = withBoxProps(
           'aria-invalid': context?.hasError || undefined,
           'aria-describedby': inputWrapperContext.describedBy,
           type: 'text',
+          onInput: (event: Event) => {
+            const handler = attrs.onInput as ((event: Event) => void) | undefined
+            handler?.(event)
+            setValue((event.currentTarget as HTMLInputElement).value)
+          },
           onMousedown: (event: MouseEvent) => {
             if (!props.pointer) {
               event.stopPropagation()

--- a/packages/@mantine-vue/core/src/components/PinInput/PinInput.ts
+++ b/packages/@mantine-vue/core/src/components/PinInput/PinInput.ts
@@ -66,6 +66,7 @@ export interface PinInputProps {
   radius?: string | number
   size?: string | number
   autoFocus?: boolean
+  modelValue?: string
   value?: string
   defaultValue?: string
   onChange?: (value: string) => void
@@ -138,6 +139,7 @@ export const PinInput = withBoxProps(
       radius: { type: [String, Number] as PropType<MantineRadius>, default: undefined },
       size: { type: String as PropType<MantineSize>, default: undefined },
       autoFocus: { type: Boolean, default: false },
+      modelValue: { type: String, default: undefined },
       value: { type: String, default: undefined },
       defaultValue: { type: String, default: undefined },
       onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
@@ -180,7 +182,8 @@ export const PinInput = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(rawProps, { attrs }) {
+    emits: ['update:modelValue', 'change'],
+    setup(rawProps, { attrs, emit }) {
       const props = useProps('PinInput', defaultProps, rawProps)
       const uuid = useId(props.id)
       const focusedIndex = ref(-1)
@@ -203,12 +206,15 @@ export const PinInput = withBoxProps(
 
       const [value, setValue] = useUncontrolled<string[]>({
         value: () =>
-          props.value !== undefined ? createPinArray(currentLength.value, props.value) : undefined,
+          props.modelValue !== undefined || props.value !== undefined
+            ? createPinArray(currentLength.value, props.modelValue ?? props.value ?? '')
+            : undefined,
         defaultValue: props.defaultValue?.split('').slice(0, currentLength.value),
         finalValue: createPinArray(currentLength.value, ''),
         onChange: (nextValue) => {
           const stringValue = nextValue.join('').trim()
-          props.onChange?.(stringValue)
+          emit('update:modelValue', stringValue)
+          emit('change', stringValue)
 
           if (stringValue.length === currentLength.value && !completed.value) {
             completed.value = true
@@ -399,7 +405,6 @@ export const PinInput = withBoxProps(
                     id: `${uuid.value}-${index + 1}`,
                     inputMode: props.inputMode || (props.type === 'number' ? 'numeric' : 'text'),
                     onInput: (event: Event) => handleInput(event, index),
-                    onChange: (event: Event) => handleInput(event, index),
                     onKeydown: (event: KeyboardEvent) => handleKeyDown(event, index),
                     onFocus: (event: FocusEvent) => {
                       ;(event.target as HTMLInputElement).select()

--- a/packages/@mantine-vue/core/src/components/Radio/Radio.ts
+++ b/packages/@mantine-vue/core/src/components/Radio/Radio.ts
@@ -1,5 +1,5 @@
 import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
-import { useId, assignRef } from '@mantine-vue/hooks'
+import { useId, assignRef, useUncontrolled } from '@mantine-vue/hooks'
 import {
   withBoxProps,
   Box,
@@ -60,14 +60,6 @@ const varsResolver = createVarsResolver<any>(
   }),
 )
 
-function callHandler(handler: any, event: Event) {
-  if (Array.isArray(handler)) {
-    handler.forEach((item) => item?.(event))
-  } else {
-    handler?.(event)
-  }
-}
-
 const RadioBase = defineComponent({
   name: 'Radio',
   inheritAttrs: false,
@@ -90,8 +82,12 @@ const RadioBase = defineComponent({
     iconColor: { type: String, default: undefined },
     autoContrast: { type: Boolean, default: undefined },
     withErrorStyles: { type: Boolean, default: true },
+    modelValue: { type: Boolean, default: undefined },
     checked: { type: Boolean, default: undefined },
+    defaultChecked: { type: Boolean, default: undefined },
+    onChange: { type: Function as PropType<(checked: boolean) => void>, default: undefined },
     disabled: { type: Boolean, default: false },
+    readOnly: { type: Boolean, default: false },
     variant: { type: String as PropType<RadioVariant>, default: 'filled' },
     mod: { type: [Object, Array] as PropType<any>, default: undefined },
     classNames: { type: [Object, Function], default: undefined },
@@ -99,9 +95,20 @@ const RadioBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'update:checked', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const uuid = useId(props.id)
     const groupContext = useRadioGroupContext()
+    const [localChecked, setLocalChecked] = useUncontrolled<boolean>({
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.checked),
+      defaultValue: props.defaultChecked,
+      finalValue: false,
+      onChange: (checked) => {
+        emit('update:modelValue', checked)
+        emit('update:checked', checked)
+        emit('change', checked)
+      },
+    })
     const getStyles = useStyles({
       name: 'Radio',
       props,
@@ -127,7 +134,7 @@ const RadioBase = defineComponent({
       const iconStyles = getStyles('icon')
       const Icon = props.icon || RadioIcon
       const value = String(attrs.value ?? '')
-      const checked = groupContext ? groupContext.value === value : props.checked
+      const checked = groupContext ? groupContext.value === value : localChecked.value
       const disabled = groupContext?.disabled || props.disabled
       const size = groupContext?.size ?? props.size
       const name = groupContext?.name ?? attrs.name
@@ -163,14 +170,19 @@ const RadioBase = defineComponent({
               id,
               checked,
               disabled,
+              readonly: props.readOnly,
               name,
               type: 'radio',
               'aria-describedby': describedBy,
               mod: { error: Boolean(error), withErrorStyles: props.withErrorStyles },
               variant: props.variant,
               onChange: (event: Event) => {
-                callHandler(attrs.onChange, event)
+                if (props.readOnly) {
+                  ;(event.currentTarget as HTMLInputElement).checked = Boolean(checked)
+                  return
+                }
                 groupContext?.onChange(event)
+                setLocalChecked((event.currentTarget as HTMLInputElement).checked)
               },
             }),
             slots.icon ? slots.icon(iconStyles) : h(Icon, iconStyles),

--- a/packages/@mantine-vue/core/src/components/Radio/RadioCard/RadioCard.ts
+++ b/packages/@mantine-vue/core/src/components/Radio/RadioCard/RadioCard.ts
@@ -1,4 +1,5 @@
 import { defineComponent, h, inject, provide, type InjectionKey, type PropType } from 'vue'
+import { useUncontrolled } from '@mantine-vue/hooks'
 import {
   withBoxProps,
   createVarsResolver,
@@ -39,7 +40,10 @@ export const RadioCard = withBoxProps(
     name: 'RadioCard',
     inheritAttrs: false,
     props: {
+      modelValue: { type: Boolean, default: undefined },
       checked: { type: Boolean, default: undefined },
+      defaultChecked: { type: Boolean, default: undefined },
+      onChange: { type: Function as PropType<(checked: boolean) => void>, default: undefined },
       withBorder: { type: Boolean, default: true },
       radius: { type: [String, Number] as PropType<MantineRadius>, default: undefined },
       value: { type: String, default: undefined },
@@ -50,8 +54,19 @@ export const RadioCard = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(props, { attrs, slots }) {
+    emits: ['update:modelValue', 'update:checked', 'change'],
+    setup(props, { attrs, slots, emit }) {
       const groupContext = useRadioGroupContext()
+      const [localChecked, setLocalChecked] = useUncontrolled<boolean>({
+        value: () => (props.modelValue !== undefined ? props.modelValue : props.checked),
+        defaultValue: props.defaultChecked,
+        finalValue: false,
+        onChange: (checked) => {
+          emit('update:modelValue', checked)
+          emit('update:checked', checked)
+          emit('change', checked)
+        },
+      })
       const getStyles = useStyles({
         name: 'RadioCard',
         props,
@@ -66,9 +81,7 @@ export const RadioCard = withBoxProps(
       })
 
       const isChecked = () =>
-        typeof props.checked === 'boolean'
-          ? props.checked
-          : groupContext?.value === props.value || false
+        groupContext ? groupContext.value === props.value : localChecked.value
 
       provide(RadioCardContextKey, {
         get checked() {
@@ -93,6 +106,7 @@ export const RadioCard = withBoxProps(
             onClick: (event: MouseEvent) => {
               callHandler(attrs.onClick, event)
               groupContext?.onChange(props.value || '')
+              setLocalChecked(true)
             },
           },
           () => slots.default?.(),

--- a/packages/@mantine-vue/core/src/components/Radio/RadioGroup/RadioGroup.ts
+++ b/packages/@mantine-vue/core/src/components/Radio/RadioGroup/RadioGroup.ts
@@ -39,6 +39,7 @@ export const RadioGroup = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<RadioGroupSlots>,
   props: {
+    modelValue: { type: String as PropType<string | null | undefined>, default: undefined },
     value: { type: String as PropType<string | null | undefined>, default: undefined },
     defaultValue: { type: String as PropType<string | null | undefined>, default: undefined },
     onChange: { type: Function as PropType<(value: string) => void>, default: undefined },
@@ -58,13 +59,17 @@ export const RadioGroup = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const name = useId(props.name)
     const [value, setValue] = useUncontrolled<string | null>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: '',
-      onChange: (nextValue) => props.onChange?.(String(nextValue ?? '')),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
 
     const handleChange = (eventOrValue: Event | string) => {

--- a/packages/@mantine-vue/core/src/components/Rating/Rating.ts
+++ b/packages/@mantine-vue/core/src/components/Rating/Rating.ts
@@ -61,6 +61,7 @@ export const Rating = withBoxProps(
     inheritAttrs: false,
     slots: Object as SlotsType<RatingSlots>,
     props: {
+      modelValue: { type: Number, default: undefined },
       defaultValue: { type: Number, default: undefined },
       value: { type: Number, default: undefined },
       onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
@@ -91,7 +92,8 @@ export const Rating = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(rawProps, { attrs, slots }) {
+    emits: ['update:modelValue', 'change'],
+    setup(rawProps, { attrs, slots, emit }) {
       const props = useProps('Rating', defaultProps, rawProps)
       const rootRef = ref<HTMLDivElement | null>(null)
       const hovered = ref(-1)
@@ -100,10 +102,13 @@ export const Rating = withBoxProps(
       const name = useId(props.name)
       const id = useId(props.id)
       const [currentValue, setCurrentValue] = useUncontrolled<number>({
-        value: () => props.value,
+        value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
         defaultValue: props.defaultValue,
         finalValue: 0,
-        onChange: (value) => props.onChange?.(value),
+        onChange: (value) => {
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
       })
       const getStyles = useStyles({
         name: 'Rating',

--- a/packages/@mantine-vue/core/src/components/SegmentedControl/SegmentedControl.ts
+++ b/packages/@mantine-vue/core/src/components/SegmentedControl/SegmentedControl.ts
@@ -60,6 +60,7 @@ export const SegmentedControl = defineComponent({
       type: Array as PropType<Array<string | number | SegmentedControlItem<string | number>>>,
       required: true,
     },
+    modelValue: { type: [String, Number, Boolean] as PropType<any>, default: undefined },
     value: { type: [String, Number, Boolean] as PropType<any>, default: undefined },
     defaultValue: { type: [String, Number, Boolean] as PropType<any>, default: undefined },
     onChange: { type: Function as PropType<(value: any) => void>, default: undefined },
@@ -82,7 +83,8 @@ export const SegmentedControl = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const theme = useMantineTheme()
     const uuid = useId(props.name)
     const mounted = useMounted()
@@ -90,12 +92,15 @@ export const SegmentedControl = defineComponent({
     const itemRefs = reactive<Record<string, HTMLElement | null>>({})
     const normalizedData = computed(() => normalizeData(props.data))
     const [value, setValue] = useUncontrolled<any>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue:
         normalizedData.value.find((item) => !item.disabled)?.value ??
         normalizedData.value[0]?.value,
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
     const getStyles = useStyles({
       name: 'SegmentedControl',

--- a/packages/@mantine-vue/core/src/components/Select/Select.ts
+++ b/packages/@mantine-vue/core/src/components/Select/Select.ts
@@ -118,7 +118,7 @@ export const Select = defineComponent({
     },
     chevronColor: { type: String, default: undefined },
   },
-  emits: ['update:modelValue', 'update:searchValue'],
+  emits: ['update:modelValue', 'update:searchValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const parsed = computed(() => getParsedComboboxData(props.data))
     const lockup = computed(() => getOptionsLockup(parsed.value))
@@ -147,8 +147,8 @@ export const Select = defineComponent({
     }
     const changeValue = (value: any, option: ComboboxItem<any> | null) => {
       if (!controlled()) internal.value = value
-      props.onChange?.(value, option)
       emit('update:modelValue', value)
+      emit('change', value, option)
     }
     const combobox = useCombobox({
       opened: () => props.dropdownOpened,

--- a/packages/@mantine-vue/core/src/components/Slider/RangeSlider/RangeSlider.ts
+++ b/packages/@mantine-vue/core/src/components/Slider/RangeSlider/RangeSlider.ts
@@ -73,6 +73,7 @@ export const RangeSlider = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<RangeSliderSlots>,
   props: {
+    modelValue: { type: Array as unknown as PropType<RangeSliderValue>, default: undefined },
     value: { type: Array as unknown as PropType<RangeSliderValue>, default: undefined },
     defaultValue: { type: Array as unknown as PropType<RangeSliderValue>, default: undefined },
     onChange: { type: Function as PropType<(value: RangeSliderValue) => void>, default: undefined },
@@ -118,17 +119,21 @@ export const RangeSlider = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(rawProps, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(rawProps, { attrs, slots, emit }) {
     const props = useProps('RangeSlider', defaults as any, rawProps) as any
     const direction = useDirection()
     const activeThumb = ref(0)
     const focused = ref(0)
     const hovered = ref(false)
     const [current, setCurrent] = useUncontrolled<RangeSliderValue>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: [props.min, props.max],
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const valueRef = ref<RangeSliderValue>([...current.value])
     watch(current, (value) => (valueRef.value = [...value]))

--- a/packages/@mantine-vue/core/src/components/Slider/Slider/Slider.ts
+++ b/packages/@mantine-vue/core/src/components/Slider/Slider/Slider.ts
@@ -88,6 +88,7 @@ export const Slider = withBoxProps(
       domain: { type: Array as unknown as PropType<[number, number]>, default: undefined },
       step: { type: Number, default: undefined },
       precision: { type: Number, default: undefined },
+      modelValue: { type: Number, default: undefined },
       value: { type: Number, default: undefined },
       defaultValue: { type: Number, default: undefined },
       onChange: { type: Function as PropType<(value: number) => void>, default: undefined },
@@ -118,20 +119,28 @@ export const Slider = withBoxProps(
       vars: { type: [Object, Function], default: undefined },
       unstyled: { type: Boolean, default: false },
     },
-    setup(rawProps, { attrs, slots }) {
+    emits: ['update:modelValue', 'change'],
+    setup(rawProps, { attrs, slots, emit }) {
       const props = useProps('Slider', defaultProps as any, rawProps) as any
       const direction = useDirection()
       const hovered = ref(false)
       const thumb = ref<HTMLElement | null>(null)
       const [current, setCurrent] = useUncontrolled<number>({
-        value: () =>
-          props.value === undefined ? undefined : clamp(props.value, props.min, props.max),
+        value: () => {
+          const controlledValue = props.modelValue !== undefined ? props.modelValue : props.value
+          return controlledValue === undefined
+            ? undefined
+            : clamp(controlledValue, props.min, props.max)
+        },
         defaultValue:
           props.defaultValue === undefined
             ? undefined
             : clamp(props.defaultValue, props.min, props.max),
         finalValue: clamp(0, props.min, props.max),
-        onChange: (value) => props.onChange?.(value),
+        onChange: (value) => {
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
       })
       const valueRef = ref(current.value)
       watch(current, (value) => {

--- a/packages/@mantine-vue/core/src/components/Switch/Switch.ts
+++ b/packages/@mantine-vue/core/src/components/Switch/Switch.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, ref, type PropType, type SlotsType, type VNodeChild } from 'vue'
+import { defineComponent, h, type PropType, type SlotsType, type VNodeChild } from 'vue'
 import { useId, useUncontrolled, assignRef } from '@mantine-vue/hooks'
 import {
   withBoxProps,
@@ -53,14 +53,6 @@ const varsResolver = createVarsResolver<any>((theme, { radius, color, size }) =>
   },
 }))
 
-function callHandler(handler: any, event: Event) {
-  if (Array.isArray(handler)) {
-    handler.forEach((item) => item?.(event))
-  } else {
-    handler?.(event)
-  }
-}
-
 const SwitchBase = defineComponent({
   name: 'Switch',
   inheritAttrs: false,
@@ -83,10 +75,12 @@ const SwitchBase = defineComponent({
     },
     rootRef: { type: [Object, Function] as PropType<any>, default: undefined },
     withThumbIndicator: { type: Boolean, default: true },
+    modelValue: { type: Boolean, default: undefined },
     checked: { type: Boolean, default: undefined },
     defaultChecked: { type: Boolean, default: undefined },
-    onChange: { type: Function as PropType<(event: Event) => void>, default: undefined },
+    onChange: { type: Function as PropType<(checked: boolean) => void>, default: undefined },
     disabled: { type: Boolean, default: false },
+    readOnly: { type: Boolean, default: false },
     variant: { type: String, default: undefined },
     mod: { type: [Object, Array] as PropType<any>, default: undefined },
     classNames: { type: [Object, Function], default: undefined },
@@ -94,16 +88,18 @@ const SwitchBase = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'update:checked', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const uuid = useId(props.id)
     const groupContext = useSwitchGroupContext()
-    const internalChecked = ref(false)
     const [checked, setChecked] = useUncontrolled<boolean>({
-      value: () => props.checked,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.checked),
       defaultValue: props.defaultChecked,
       finalValue: false,
       onChange: (value) => {
-        internalChecked.value = value
+        emit('update:modelValue', value)
+        emit('update:checked', value)
+        emit('change', value)
       },
     })
     const getStyles = useStyles({
@@ -166,18 +162,21 @@ const SwitchBase = defineComponent({
             ...getStyles('input'),
             disabled,
             checked: currentChecked,
+            readonly: props.readOnly,
             id,
             type: 'checkbox',
             role: 'switch',
             'aria-describedby': describedBy,
             onChange: (event: Event) => {
-              callHandler(attrs.onChange, event)
-              props.onChange?.(event)
+              if (props.readOnly) {
+                ;(event.currentTarget as HTMLInputElement).checked = currentChecked
+                return
+              }
+              const nextChecked = (event.currentTarget as HTMLInputElement).checked
               if (groupContext) {
                 groupContext.onChange(event)
-              } else {
-                setChecked((event.currentTarget as HTMLInputElement).checked)
               }
+              setChecked(nextChecked)
             },
           }),
           h(

--- a/packages/@mantine-vue/core/src/components/Switch/SwitchGroup/SwitchGroup.ts
+++ b/packages/@mantine-vue/core/src/components/Switch/SwitchGroup/SwitchGroup.ts
@@ -15,7 +15,7 @@ import { InputsGroupFieldset } from '../../../utils'
 
 export interface SwitchGroupContextValue {
   value: string[]
-  onChange: (event: Event) => void
+  onChange: (eventOrValue: Event | string) => void
   size?: string | number
   isDisabled?: (value: string) => boolean
 }
@@ -38,6 +38,7 @@ export const SwitchGroup = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<SwitchGroupSlots>,
   props: {
+    modelValue: { type: Array as PropType<string[] | undefined>, default: undefined },
     value: { type: Array as PropType<string[] | undefined>, default: undefined },
     defaultValue: { type: Array as PropType<string[] | undefined>, default: undefined },
     onChange: { type: Function as PropType<(value: string[]) => void>, default: undefined },
@@ -60,20 +61,27 @@ export const SwitchGroup = defineComponent({
     vars: { type: [Object, Function], default: undefined },
     unstyled: { type: Boolean, default: false },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const [value, setValue] = useUncontrolled<string[]>({
-      value: () => props.value,
+      value: () => (props.modelValue !== undefined ? props.modelValue : props.value),
       defaultValue: props.defaultValue,
       finalValue: [],
-      onChange: (nextValue) => props.onChange?.(nextValue),
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
     })
 
-    const handleChange = (event: Event) => {
+    const handleChange = (eventOrValue: Event | string) => {
       if (props.readOnly) {
         return
       }
 
-      const itemValue = String((event.currentTarget as HTMLInputElement | null)?.value ?? '')
+      const itemValue =
+        typeof eventOrValue === 'string'
+          ? eventOrValue
+          : String((eventOrValue.currentTarget as HTMLInputElement | null)?.value ?? '')
       const isCurrentlySelected = value.value.includes(itemValue)
 
       if (

--- a/packages/@mantine-vue/core/src/components/TagsInput/TagsInput.ts
+++ b/packages/@mantine-vue/core/src/components/TagsInput/TagsInput.ts
@@ -127,7 +127,7 @@ export const TagsInput = defineComponent({
     openOnFocus: { type: Boolean, default: true },
     selectFirstOptionOnDropdownOpen: Boolean,
   },
-  emits: ['update:modelValue', 'update:searchValue'],
+  emits: ['update:modelValue', 'update:searchValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const parsed = computed(() => getParsedComboboxData(props.data))
     const lockup = computed(() => getOptionsLockup(parsed.value))
@@ -144,8 +144,8 @@ export const TagsInput = defineComponent({
     }
     const setValue = (value: string[]) => {
       if (!controlled()) internal.value = value
-      props.onChange?.(value)
       emit('update:modelValue', value)
+      emit('change', value)
     }
     const combobox = useCombobox({
       opened: () => props.dropdownOpened,

--- a/packages/@mantine-vue/core/src/components/TextInput/TextInput.ts
+++ b/packages/@mantine-vue/core/src/components/TextInput/TextInput.ts
@@ -1,15 +1,32 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, type PropType } from 'vue'
 import { InputBase } from '../InputBase'
 
 export const TextInput = defineComponent({
   name: 'TextInput',
   inheritAttrs: false,
-  setup(_, { attrs, slots }) {
+  props: {
+    modelValue: {
+      type: [String, Number] as PropType<string | number | undefined>,
+      default: undefined,
+    },
+    value: { type: [String, Number] as PropType<string | number | undefined>, default: undefined },
+    defaultValue: {
+      type: [String, Number] as PropType<string | number | undefined>,
+      default: undefined,
+    },
+  },
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     return () =>
       h(
         InputBase,
         {
           ...attrs,
+          modelValue: props.modelValue,
+          value: props.value,
+          defaultValue: props.defaultValue,
+          'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+          onChange: (value: string) => emit('change', value),
           component: 'input',
           __staticSelector: 'TextInput',
           __stylesApiProps: attrs,

--- a/packages/@mantine-vue/core/src/components/Textarea/Textarea.ts
+++ b/packages/@mantine-vue/core/src/components/Textarea/Textarea.ts
@@ -13,6 +13,9 @@ export const Textarea = defineComponent({
   inheritAttrs: false,
   slots: Object as SlotsType<TextareaSlots>,
   props: {
+    modelValue: { type: String, default: undefined },
+    value: { type: String, default: undefined },
+    defaultValue: { type: String, default: undefined },
     autosize: { type: Boolean, default: false },
     maxRows: { type: Number, default: undefined },
     minRows: { type: Number, default: undefined },
@@ -27,7 +30,8 @@ export const Textarea = defineComponent({
     bottomSectionProps: { type: Object as PropType<Record<string, any>>, default: undefined },
     __staticSelector: { type: String, default: undefined },
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     return () => {
       const shouldAutosize = props.autosize
       const autosizeProps = shouldAutosize
@@ -38,6 +42,11 @@ export const Textarea = defineComponent({
         InputBase,
         {
           ...attrs,
+          modelValue: props.modelValue,
+          value: props.value,
+          defaultValue: props.defaultValue,
+          'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+          onChange: (value: string) => emit('change', value),
           component: shouldAutosize ? TextareaAutosize : 'textarea',
           __staticSelector: props.__staticSelector || 'Textarea',
           multiline: true,

--- a/packages/@mantine-vue/core/src/components/TreeSelect/TreeSelect.ts
+++ b/packages/@mantine-vue/core/src/components/TreeSelect/TreeSelect.ts
@@ -369,17 +369,22 @@ export const TreeSelect = defineComponent({
     openOnFocus: { type: Boolean, default: true },
     chevronAriaLabels: Object as PropType<TreeSelectChevronAriaLabels>,
   },
-  emits: ['update:modelValue', 'update:searchValue'],
+  emits: ['update:modelValue', 'update:searchValue', 'change'],
   setup(props, { attrs, emit, slots }) {
     const isMulti = () => props.mode !== 'single'
 
     const initial = props.defaultValue !== undefined ? props.defaultValue : isMulti() ? [] : null
     const internal = ref<any>(initial)
-    const current = () => props.modelValue ?? props.value ?? internal.value
+    const current = () =>
+      props.modelValue !== undefined
+        ? props.modelValue
+        : props.value !== undefined
+          ? props.value
+          : internal.value
     const setValue = (value: any) => {
       if (props.modelValue === undefined && props.value === undefined) internal.value = value
-      props.onChange?.(value)
       emit('update:modelValue', value)
+      emit('change', value)
     }
 
     const initialExpanded = props.defaultExpandAll

--- a/packages/@mantine-vue/core/src/components/__tests__/menu.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/menu.test.ts
@@ -250,11 +250,7 @@ describe('@mantine-vue/core Menu', () => {
 
     await wrapper.find('.target').trigger('click')
 
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        currentTarget: expect.objectContaining({ value: '' }),
-      }),
-    )
+    expect(onChange).toHaveBeenCalledWith('')
   })
 
   it('opens nested submenus on hover', async () => {

--- a/packages/@mantine-vue/core/src/components/__tests__/native-select.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/native-select.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { h } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { MantineProvider, NativeSelect, getParsedNativeSelectData } from '../../index'
 
@@ -58,7 +58,7 @@ describe('@mantine-vue/core NativeSelect', () => {
   })
 
   it('supports controlled value and change handler', async () => {
-    const onChange = vi.fn((event: Event) => (event.target as HTMLSelectElement).value)
+    const onChange = vi.fn((value: string) => value)
     const wrapper = withProvider({ data: ['test-1', 'test-2'], value: 'test-1', onChange })
     const select = wrapper.find('select')
 
@@ -66,6 +66,27 @@ describe('@mantine-vue/core NativeSelect', () => {
 
     expect(onChange).toHaveReturnedWith('test-2')
     expect((select.element as HTMLSelectElement).value).toBe('test-1')
+  })
+
+  it('supports v-model in both directions', async () => {
+    const value = ref('test-1')
+    const wrapper = mount({
+      components: { MantineProvider, NativeSelect },
+      setup: () => ({ value }),
+      template: `
+        <MantineProvider env="test">
+          <NativeSelect v-model="value" :data="['test-1', 'test-2']" />
+        </MantineProvider>
+      `,
+    })
+    const select = wrapper.get('select')
+
+    value.value = 'test-2'
+    await nextTick()
+    expect((select.element as HTMLSelectElement).value).toBe('test-2')
+
+    await select.setValue('test-1')
+    expect(value.value).toBe('test-1')
   })
 
   it('prefers children over data', () => {

--- a/packages/@mantine-vue/core/src/components/__tests__/v-model.test.ts
+++ b/packages/@mantine-vue/core/src/components/__tests__/v-model.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest'
+import { h, nextTick, ref, type Component } from 'vue'
+import { mount } from '@vue/test-utils'
+import {
+  AngleSlider,
+  Checkbox,
+  CheckboxGroup,
+  Chip,
+  ChipGroup,
+  ColorPicker,
+  Input,
+  InputBase,
+  JsonInput,
+  MantineProvider,
+  NumberInput,
+  PasswordInput,
+  PillsInputField,
+  PinInput,
+  Radio,
+  RadioGroup,
+  RangeSlider,
+  Rating,
+  SegmentedControl,
+  Slider,
+  Switch,
+  SwitchGroup,
+  Textarea,
+  TextInput,
+} from '../../index'
+
+function renderModel<T>(component: Component, initialValue: T, props: Record<string, any> = {}) {
+  const value = ref(initialValue)
+  const onChange = vi.fn()
+  const wrapper = mount({
+    render: () =>
+      h(MantineProvider, { env: 'test' }, () =>
+        h(component, {
+          ...props,
+          modelValue: value.value,
+          'onUpdate:modelValue': (nextValue: T) => (value.value = nextValue),
+          onChange,
+        }),
+      ),
+  })
+
+  return { onChange, value, wrapper }
+}
+
+describe('@mantine-vue/core v-model', () => {
+  it.each([
+    ['Input', Input, 'input'],
+    ['InputBase', InputBase, 'input'],
+    ['TextInput', TextInput, 'input'],
+    ['Textarea', Textarea, 'textarea'],
+    ['PasswordInput', PasswordInput, 'input'],
+    ['PillsInput.Field', PillsInputField, 'input'],
+  ])('binds %s values in both directions and emits raw strings', async (_, component, selector) => {
+    const { onChange, value, wrapper } = renderModel(component, 'initial')
+    const input = wrapper.get(selector)
+
+    value.value = 'external'
+    await nextTick()
+    expect((input.element as HTMLInputElement).value).toBe('external')
+
+    await input.setValue('user')
+    expect(value.value).toBe('user')
+    expect(onChange).toHaveBeenLastCalledWith('user')
+  })
+
+  it.each([
+    ['Checkbox', Checkbox, 'input[type="checkbox"]'],
+    ['Switch', Switch, 'input[role="switch"]'],
+    ['Chip', Chip, 'input'],
+  ])('binds %s boolean state and emits raw booleans', async (_, component, selector) => {
+    const { onChange, value, wrapper } = renderModel(component, false, {
+      label: 'Control',
+      value: 'control',
+    })
+    const input = wrapper.get(selector)
+
+    value.value = true
+    await nextTick()
+    expect((input.element as HTMLInputElement).checked).toBe(true)
+
+    await input.setValue(false)
+    expect(value.value).toBe(false)
+    expect(onChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('binds Radio boolean state and emits a raw boolean', async () => {
+    const { onChange, value, wrapper } = renderModel(Radio, false, {
+      label: 'Radio',
+      value: 'radio',
+    })
+    const input = wrapper.get('input[type="radio"]')
+
+    await input.setValue(true)
+    expect(value.value).toBe(true)
+    expect(onChange).toHaveBeenLastCalledWith(true)
+
+    value.value = false
+    await nextTick()
+    expect((input.element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('binds selection group values in both directions', async () => {
+    const checkboxValue = ref<string[]>(['a'])
+    const radioValue = ref('a')
+    const switchValue = ref<string[]>(['a'])
+    const chipValue = ref<string | null>('a')
+    const wrapper = mount({
+      components: {
+        Checkbox,
+        CheckboxGroup,
+        Chip,
+        ChipGroup,
+        MantineProvider,
+        Radio,
+        RadioGroup,
+        Switch,
+        SwitchGroup,
+      },
+      setup: () => ({ checkboxValue, chipValue, radioValue, switchValue }),
+      template: `
+        <MantineProvider env="test">
+          <CheckboxGroup v-model="checkboxValue">
+            <Checkbox value="a" label="Checkbox A" />
+            <Checkbox value="b" label="Checkbox B" />
+          </CheckboxGroup>
+          <RadioGroup v-model="radioValue">
+            <Radio value="a" label="Radio A" />
+            <Radio value="b" label="Radio B" />
+          </RadioGroup>
+          <SwitchGroup v-model="switchValue">
+            <Switch value="a" label="Switch A" />
+            <Switch value="b" label="Switch B" />
+          </SwitchGroup>
+          <ChipGroup v-model="chipValue">
+            <Chip value="a">Chip A</Chip>
+            <Chip value="b">Chip B</Chip>
+          </ChipGroup>
+        </MantineProvider>
+      `,
+    })
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    const radios = wrapper.findAll('input[type="radio"]')
+
+    await checkboxes[1].setValue(true)
+    await radios[1].setValue(true)
+    await wrapper.findAll('input[role="switch"]')[1].setValue(true)
+    await wrapper.findAll('.mantine-Chip-input')[1].setValue(true)
+
+    expect(checkboxValue.value).toEqual(['a', 'b'])
+    expect(radioValue.value).toBe('b')
+    expect(switchValue.value).toEqual(['a', 'b'])
+    expect(chipValue.value).toBe('b')
+  })
+
+  it('binds formatted and composite input values', async () => {
+    const number = renderModel(NumberInput, 1)
+    await number.wrapper.get('input').setValue('42')
+    expect(number.value.value).toBe(42)
+    expect(number.onChange).toHaveBeenLastCalledWith(42)
+
+    const json = renderModel(JsonInput, '{"a":1}')
+    await json.wrapper.get('textarea').setValue('{"b":2}')
+    expect(json.value.value).toBe('{"b":2}')
+
+    const pin = renderModel(PinInput, '', { length: 2 })
+    await pin.wrapper.findAll('input[type="text"]')[0].setValue('7')
+    expect(pin.value.value).toBe('7')
+
+    const segmented = renderModel(SegmentedControl, 'a', { data: ['a', 'b'] })
+    await segmented.wrapper.findAll('input')[1].setValue(true)
+    expect(segmented.value.value).toBe('b')
+    expect(segmented.onChange).toHaveBeenLastCalledWith('b')
+  })
+
+  it('binds slider, rating, and color control values', async () => {
+    const slider = renderModel(Slider, 20)
+    await slider.wrapper.get('[role="slider"]').trigger('keydown', { key: 'ArrowRight' })
+    expect(slider.value.value).toBe(21)
+
+    const range = renderModel(RangeSlider, [20, 80] as [number, number])
+    await range.wrapper.findAll('[role="slider"]')[0].trigger('keydown', { key: 'ArrowRight' })
+    expect(range.value.value).toEqual([21, 80])
+
+    const angle = renderModel(AngleSlider, 45)
+    await angle.wrapper.get('[role="slider"]').trigger('keydown', { key: 'ArrowRight' })
+    expect(angle.value.value).toBe(46)
+
+    const rating = renderModel(Rating, 1)
+    const secondRating = rating.wrapper
+      .findAll('input[type="radio"]')
+      .find((input) => input.element.value === '2')!
+    secondRating.element.nextElementSibling?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    )
+    await nextTick()
+    expect(rating.value.value).toBe(2)
+
+    const color = renderModel(ColorPicker, '#ff0000', {
+      withPicker: false,
+      swatches: ['#ff0000', '#00ff00'],
+    })
+    await color.wrapper.get('[aria-label="#00ff00"]').trigger('click')
+    expect(color.value.value).toBe('#00ff00')
+  })
+})

--- a/packages/@mantine-vue/dates/src/__tests__/dates.test.ts
+++ b/packages/@mantine-vue/dates/src/__tests__/dates.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { h } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { MantineProvider } from '@mantine-vue/core'
 import {
   Day,
+  AmPmInput,
+  DateInput,
+  DatePicker,
+  MiniCalendar,
+  SpinInput,
+  TimeGrid,
+  TimeInput,
   assignTime,
   clampDate,
   compareTime,
@@ -17,6 +24,74 @@ import {
   padTime,
   toDateString,
 } from '../index'
+
+describe('@mantine-vue/dates v-model', () => {
+  it('binds native and segmented time inputs in both directions', async () => {
+    const nativeTime = ref('10:15')
+    const gridTime = ref<string | null>('10:00')
+    const spinValue = ref<number | null>(1)
+    const period = ref<string | null>('AM')
+    const wrapper = mount({
+      components: { AmPmInput, MantineProvider, SpinInput, TimeGrid, TimeInput },
+      setup: () => ({ gridTime, nativeTime, period, spinValue }),
+      template: `
+        <MantineProvider env="test">
+          <TimeInput v-model="nativeTime" />
+          <TimeGrid v-model="gridTime" :data="['10:00', '10:30']" />
+          <SpinInput v-model="spinValue" :min="0" :max="23" />
+          <AmPmInput v-model="period" :labels="{ am: 'AM', pm: 'PM' }" />
+        </MantineProvider>
+      `,
+    })
+
+    await wrapper.get('input[type="time"]').setValue('11:45')
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text() === '10:30')!
+      .trigger('click')
+    await wrapper.get('input[role="spinbutton"]').setValue('12')
+    await wrapper.get('select').setValue('PM')
+
+    expect(nativeTime.value).toBe('11:45')
+    expect(gridTime.value).toBe('10:30')
+    expect(spinValue.value).toBe(12)
+    expect(period.value).toBe('PM')
+  })
+
+  it('binds date controls and reflects external model updates', async () => {
+    const date = ref<string | null>('2024-01-15')
+    const typedDate = ref<string | null>('2024-01-15')
+    const miniDate = ref<string | null>('2024-01-15')
+    const wrapper = mount({
+      components: { DateInput, DatePicker, MantineProvider, MiniCalendar },
+      setup: () => ({ date, miniDate, typedDate }),
+      template: `
+        <MantineProvider env="test">
+          <DatePicker v-model="date" default-date="2024-01-01" />
+          <DateInput v-model="typedDate" value-format="YYYY-MM-DD" />
+          <MiniCalendar
+            v-model="miniDate"
+            default-date="2024-01-15"
+            :number-of-days="2"
+          />
+        </MantineProvider>
+      `,
+    })
+
+    await wrapper
+      .findAll('table button')
+      .find((button) => button.text() === '20')!
+      .trigger('click')
+    expect(date.value).toBe('2024-01-20')
+
+    typedDate.value = '2024-02-03'
+    await nextTick()
+    expect((wrapper.get('input').element as HTMLInputElement).value).toBe('2024-02-03')
+
+    await wrapper.get('[aria-label="2024-01-16"]').trigger('click')
+    expect(miniDate.value).toBe('2024-01-16')
+  })
+})
 
 describe('TimePicker 9.5 duration support', () => {
   it('formats hour values greater than 9999 without truncation', () => {

--- a/packages/@mantine-vue/dates/src/index.ts
+++ b/packages/@mantine-vue/dates/src/index.ts
@@ -1350,6 +1350,7 @@ export const DatePicker = defineComponent({
   slots: Object as SlotsType<RenderDaySlots>,
   props: {
     type: { type: String as PropType<DatePickerType>, default: 'default' },
+    modelValue: [String, Array, null] as PropType<DatePickerValueType>,
     value: [String, Array, null] as PropType<DatePickerValueType>,
     defaultValue: [String, Array, null] as PropType<DatePickerValueType>,
     onChange: Function as PropType<(value: DatePickerValueType) => void>,
@@ -1359,15 +1360,19 @@ export const DatePicker = defineComponent({
     withNativeLevelSelect: Boolean,
     yearsSelectRange: Array as unknown as PropType<[number, number]>,
   },
-  setup(props, { attrs, slots }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, slots, emit }) {
     const finalValue = computed<DatePickerValueType>(() =>
       props.type === 'multiple' ? [] : props.type === 'range' ? [null, null] : null,
     )
     const [_value, setValue] = useUncontrolled<DatePickerValueType>({
-      value: computed(() => props.value),
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
       defaultValue: props.defaultValue,
       finalValue: finalValue.value,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const selectDate = (date: DateStringValue) => {
       if (
@@ -1456,6 +1461,7 @@ export const YearPicker = defineComponent({
   name: 'YearPicker',
   props: {
     type: { type: String as PropType<DatePickerType>, default: 'default' },
+    modelValue: [String, Array, null] as PropType<DatePickerValueType>,
     value: [String, Array, null] as PropType<DatePickerValueType>,
     defaultValue: [String, Array, null] as PropType<DatePickerValueType>,
     onChange: Function as PropType<(value: DatePickerValueType) => void>,
@@ -1466,15 +1472,19 @@ export const YearPicker = defineComponent({
     withNativeLevelSelect: Boolean,
     yearsSelectRange: Array as unknown as PropType<[number, number]>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const finalValue = computed<DatePickerValueType>(() =>
       props.type === 'multiple' ? [] : props.type === 'range' ? [null, null] : null,
     )
     const [_value, setValue] = useUncontrolled<DatePickerValueType>({
-      value: computed(() => props.value),
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
       defaultValue: props.defaultValue,
       finalValue: finalValue.value,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const hoveredDate = ref<DateStringValue | null>(null)
     const selectYear = (date: DateStringValue) => {
@@ -1583,6 +1593,7 @@ export const MonthPicker = defineComponent({
   name: 'MonthPicker',
   props: {
     type: { type: String as PropType<DatePickerType>, default: 'default' },
+    modelValue: [String, Array, null] as PropType<DatePickerValueType>,
     value: [String, Array, null] as PropType<DatePickerValueType>,
     defaultValue: [String, Array, null] as PropType<DatePickerValueType>,
     onChange: Function as PropType<(value: DatePickerValueType) => void>,
@@ -1593,15 +1604,19 @@ export const MonthPicker = defineComponent({
     withNativeLevelSelect: Boolean,
     yearsSelectRange: Array as unknown as PropType<[number, number]>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const finalValue = computed<DatePickerValueType>(() =>
       props.type === 'multiple' ? [] : props.type === 'range' ? [null, null] : null,
     )
     const [_value, setValue] = useUncontrolled<DatePickerValueType>({
-      value: computed(() => props.value),
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
       defaultValue: props.defaultValue,
       finalValue: finalValue.value,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const hoveredDate = ref<DateStringValue | null>(null)
     const selectMonth = (date: DateStringValue) => {
@@ -1825,6 +1840,7 @@ function createPickerInput(
     name,
     props: {
       type: { type: String as PropType<DatePickerType>, default: 'default' },
+      modelValue: [String, Array, null] as PropType<DatePickerValueType>,
       value: [String, Array, null] as PropType<DatePickerValueType>,
       defaultValue: [String, Array, null] as PropType<DatePickerValueType>,
       onChange: Function as PropType<(value: DatePickerValueType) => void>,
@@ -1840,15 +1856,19 @@ function createPickerInput(
       withNativeLevelSelect: Boolean,
       yearsSelectRange: Array as unknown as PropType<[number, number]>,
     },
-    setup(props, { attrs }) {
+    emits: ['update:modelValue', 'change'],
+    setup(props, { attrs, emit }) {
       const finalValue = computed<DatePickerValueType>(() =>
         props.type === 'multiple' ? [] : props.type === 'range' ? [null, null] : null,
       )
       const [_value, setValue] = useUncontrolled<DatePickerValueType>({
-        value: computed(() => props.value),
+        value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
         defaultValue: props.defaultValue,
         finalValue: finalValue.value,
-        onChange: (value) => props.onChange?.(value),
+        onChange: (value) => {
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
       })
       const opened = ref(false)
       const formattedValue = computed(() =>
@@ -1947,6 +1967,7 @@ export const DateInput = defineComponent({
   name: 'DateInput',
   inheritAttrs: false,
   props: {
+    modelValue: [String, Date, null] as PropType<string | Date | null>,
     value: [String, Date, null] as PropType<string | Date | null>,
     defaultValue: [String, Date, null] as PropType<string | Date | null>,
     onChange: Function as PropType<(value: DateValue) => void>,
@@ -1961,17 +1982,24 @@ export const DateInput = defineComponent({
   // A free-text input that also opens a Calendar dropdown (in a Popover,
   // same as DatePickerInput) on focus/click, so users can either type a
   // date or pick it from the calendar.
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const [_value, setValue] = useUncontrolled<DateValue>({
       // normalizeDate() coerces a missing prop to `null`, but useUncontrolled
       // relies on strict `undefined` to detect "no value prop passed" (i.e.
       // uncontrolled usage). Coercing to null here made the component always
       // look controlled-with-null, so setValue() never actually updated
       // anything without an external value/onChange binding.
-      value: computed(() => (props.value === undefined ? undefined : normalizeDate(props.value))),
+      value: computed(() => {
+        const controlledValue = props.modelValue !== undefined ? props.modelValue : props.value
+        return controlledValue === undefined ? undefined : normalizeDate(controlledValue)
+      }),
       defaultValue: normalizeDate(props.defaultValue),
       finalValue: null,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const formatValue = (value: DateValue) =>
       value
@@ -2198,19 +2226,23 @@ export const TimeInput = defineComponent({
   name: 'TimeInput',
   props: {
     withSeconds: Boolean,
+    modelValue: String,
     value: String,
     defaultValue: String,
-    onChange: Function as PropType<(event: Event) => void>,
+    onChange: Function as PropType<(value: string) => void>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     return () =>
       h(InputBase, {
         ...attrs,
         type: 'time',
         step: props.withSeconds ? 1 : 60,
+        modelValue: props.modelValue,
         value: props.value,
         defaultValue: props.defaultValue,
-        onChange: props.onChange,
+        'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+        onChange: (value: string) => emit('change', value),
       })
   },
 })
@@ -2222,6 +2254,7 @@ export const TimeGrid = defineComponent({
   name: 'TimeGrid',
   props: {
     data: { type: Array as PropType<string[]>, default: () => [] },
+    modelValue: String,
     value: String,
     defaultValue: String,
     minTime: String,
@@ -2231,12 +2264,16 @@ export const TimeGrid = defineComponent({
     onChange: Function as PropType<(value: string | null) => void>,
     getControlProps: Function as PropType<(value: string) => Record<string, any>>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const [_value, setValue] = useUncontrolled<string | null>({
-      value: computed(() => props.value),
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
       defaultValue: props.defaultValue,
       finalValue: null,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     return () =>
       h(Box, { ...attrs, class: [classes.timeGridRoot, (attrs as any).class] }, () =>
@@ -2279,7 +2316,9 @@ export const SpinInput = defineComponent({
   name: 'SpinInput',
   inheritAttrs: false,
   props: {
-    value: { type: Number as PropType<number | null>, default: null },
+    modelValue: { type: Number as PropType<number | null | undefined>, default: undefined },
+    value: { type: Number as PropType<number | null | undefined>, default: undefined },
+    defaultValue: { type: Number as PropType<number | null | undefined>, default: undefined },
     min: { type: Number, required: true },
     max: { type: Number, required: true },
     onChange: Function as PropType<(value: number | null) => void>,
@@ -2292,7 +2331,17 @@ export const SpinInput = defineComponent({
     disabled: Boolean,
     readOnly: Boolean,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
+    const [value, setValue] = useUncontrolled<number | null>({
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
+      defaultValue: props.defaultValue,
+      finalValue: null,
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
     const finiteMax = () => Number.isFinite(props.max)
     const maxDigit = () => (finiteMax() ? Number(props.max.toFixed(0)[0]) : Infinity)
     const arrowsMax = () => props.max + 1 - props.step
@@ -2313,7 +2362,7 @@ export const SpinInput = defineComponent({
           : finiteMax()
             ? Math.min(Math.max(parsedValue, props.min), props.max)
             : Math.max(parsedValue, props.min)
-      props.onChange?.(clampedValue)
+      setValue(clampedValue)
       if (!props.disableAutoAdvance && (clampedValue > maxDigit() || raw.startsWith('00'))) {
         props.onNextInput?.()
       }
@@ -2326,22 +2375,22 @@ export const SpinInput = defineComponent({
         const { selectionStart, selectionEnd, value: inputValue } = target
         const isEntireValueSelected =
           inputValue.length > 0 && selectionStart === 0 && selectionEnd === inputValue.length
-        if (props.value === 0 && !isEntireValueSelected) {
+        if (value.value === 0 && !isEntireValueSelected) {
           event.preventDefault()
           props.onNextInput?.()
         }
       }
       if (event.key === 'Home') {
         event.preventDefault()
-        props.onChange?.(props.min)
+        setValue(props.min)
       }
       if (event.key === 'End') {
         event.preventDefault()
-        if (finiteMax()) props.onChange?.(props.max)
+        if (finiteMax()) setValue(props.max)
       }
       if (event.key === 'Backspace' || event.key === 'Delete') {
         event.preventDefault()
-        if (props.value !== null) props.onChange?.(null)
+        if (value.value !== null) setValue(null)
         else props.onPreviousInput?.()
       }
       if (event.key === 'ArrowRight') {
@@ -2355,22 +2404,22 @@ export const SpinInput = defineComponent({
       if (event.key === 'ArrowUp') {
         event.preventDefault()
         const newValue =
-          props.value === null
+          value.value === null
             ? props.min
             : finiteMax()
-              ? Math.min(Math.max(props.value + props.step, props.min), arrowsMax())
-              : Math.max(props.value + props.step, props.min)
-        props.onChange?.(newValue)
+              ? Math.min(Math.max(value.value + props.step, props.min), arrowsMax())
+              : Math.max(value.value + props.step, props.min)
+        setValue(newValue)
       }
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         const newValue =
-          props.value === null
+          value.value === null
             ? finiteMax()
               ? arrowsMax()
               : props.min
-            : Math.min(Math.max(props.value - props.step, props.min), arrowsMax())
-        props.onChange?.(newValue)
+            : Math.min(Math.max(value.value - props.step, props.min), arrowsMax())
+        setValue(newValue)
       }
     }
 
@@ -2381,13 +2430,13 @@ export const SpinInput = defineComponent({
         role: 'spinbutton',
         'aria-valuemin': props.min,
         'aria-valuemax': finiteMax() ? props.max : undefined,
-        'aria-valuenow': props.value === null ? 0 : props.value,
-        'data-empty': props.value === null || undefined,
+        'aria-valuenow': value.value === null ? 0 : value.value,
+        'data-empty': value.value === null || undefined,
         inputmode: 'numeric',
         placeholder: props.placeholder,
         disabled: props.disabled,
         readonly: props.readOnly,
-        value: props.value === null ? '' : padTime(props.value),
+        value: value.value === null ? '' : padTime(value.value),
         onInput: (event: Event) => handleChange((event.target as HTMLInputElement).value),
         onKeydown: handleKeydown,
         onFocus: (event: FocusEvent) => (event.target as HTMLInputElement).select(),
@@ -2403,13 +2452,25 @@ export const SpinInput = defineComponent({
 export const AmPmInput = defineComponent({
   name: 'AmPmInput',
   props: {
-    value: { type: String as PropType<string | null>, default: null },
+    modelValue: { type: String as PropType<string | null | undefined>, default: undefined },
+    value: { type: String as PropType<string | null | undefined>, default: undefined },
+    defaultValue: { type: String as PropType<string | null | undefined>, default: undefined },
     labels: { type: Object as PropType<TimePickerAmPmLabels>, default: () => defaultAmPmLabels },
     onChange: Function as PropType<(value: string) => void>,
     disabled: Boolean,
     readOnly: Boolean,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
+    const [value, setValue] = useUncontrolled<string | null>({
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
+      defaultValue: props.defaultValue,
+      finalValue: null,
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
     return () =>
       h(
         'select',
@@ -2418,8 +2479,8 @@ export const AmPmInput = defineComponent({
           class: classes.timePickerField,
           'data-am-pm': true,
           disabled: props.disabled,
-          value: props.value ?? props.labels.am,
-          onChange: (event: Event) => props.onChange?.((event.target as HTMLSelectElement).value),
+          value: value.value ?? props.labels.am,
+          onChange: (event: Event) => setValue((event.target as HTMLSelectElement).value),
         },
         [
           h('option', { value: props.labels.am }, props.labels.am),
@@ -2468,6 +2529,7 @@ export const TimeControlsList = defineComponent({
 export const TimePicker = defineComponent({
   name: 'TimePicker',
   props: {
+    modelValue: String,
     value: String,
     defaultValue: String,
     onChange: Function as PropType<(value: string) => void>,
@@ -2496,15 +2558,19 @@ export const TimePicker = defineComponent({
     // date is picked.
     hoursRef: Object as PropType<{ value: any }>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const effectiveFormat = computed<'12h' | '24h'>(() =>
       props.type === 'duration' ? '24h' : props.format,
     )
     const [_value, setValue] = useUncontrolled<string>({
-      value: computed(() => props.value),
+      value: computed(() => (props.modelValue !== undefined ? props.modelValue : props.value)),
       defaultValue: props.defaultValue,
       finalValue: '',
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
 
     const parsed = computed(() =>
@@ -2847,6 +2913,7 @@ export const TimeValue = defineComponent({
 export const DateTimePicker = defineComponent({
   name: 'DateTimePicker',
   props: {
+    modelValue: [String, Date, null] as PropType<string | Date | null>,
     value: [String, Date, null] as PropType<string | Date | null>,
     defaultValue: [String, Date, null] as PropType<string | Date | null>,
     onChange: Function as PropType<(value: Date | null) => void>,
@@ -2856,7 +2923,8 @@ export const DateTimePicker = defineComponent({
     size: { type: [String, Number], default: 'sm' },
     submitButtonProps: Object as PropType<Record<string, any>>,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     // Populated with the actual hours <input> DOM node once TimePicker
     // mounts (see TimePicker's hoursRef prop) so we can auto-focus it right
     // after a date is picked from the calendar.
@@ -2869,12 +2937,20 @@ export const DateTimePicker = defineComponent({
       // so picking a date/time in the dropdown never updated anything
       // without an external value/onChange binding - the picker looked
       // completely broken/inert.
-      value: computed(() =>
-        props.value === undefined ? undefined : props.value === null ? null : new Date(props.value),
-      ),
+      value: computed(() => {
+        const controlledValue = props.modelValue !== undefined ? props.modelValue : props.value
+        return controlledValue === undefined
+          ? undefined
+          : controlledValue === null
+            ? null
+            : new Date(controlledValue)
+      }),
       defaultValue: props.defaultValue ? new Date(props.defaultValue) : null,
       finalValue: null,
-      onChange: (value) => props.onChange?.(value),
+      onChange: (value) => {
+        emit('update:modelValue', value)
+        emit('change', value)
+      },
     })
     const date = computed(() => (_value.value ? dayjs(_value.value).format('YYYY-MM-DD') : null))
     const time = computed(() =>
@@ -2961,7 +3037,9 @@ export const MiniCalendar = defineComponent({
     date: [String, Date] as PropType<string | Date>,
     defaultDate: [String, Date] as PropType<string | Date>,
     onDateChange: Function as PropType<(date: DateStringValue) => void>,
+    modelValue: [String, Date, null] as PropType<string | Date | null>,
     value: [String, Date, null] as PropType<string | Date | null>,
+    defaultValue: [String, Date, null] as PropType<string | Date | null>,
     onChange: Function as PropType<(date: DateStringValue) => void>,
     maxDate: [String, Date] as PropType<string | Date>,
     minDate: [String, Date] as PropType<string | Date>,
@@ -2975,12 +3053,25 @@ export const MiniCalendar = defineComponent({
     nextControlProps: Object as PropType<Record<string, any>>,
     locale: String,
   },
-  setup(props, { attrs }) {
+  emits: ['update:modelValue', 'change'],
+  setup(props, { attrs, emit }) {
     const ctx = useDatesContext()
+    const [value, setValue] = useUncontrolled<DateValue>({
+      value: computed(() => {
+        const controlledValue = props.modelValue !== undefined ? props.modelValue : props.value
+        return controlledValue === undefined ? undefined : toDateString(controlledValue)
+      }),
+      defaultValue: toDateString(props.defaultValue ?? null),
+      finalValue: null,
+      onChange: (nextValue) => {
+        emit('update:modelValue', nextValue)
+        emit('change', nextValue)
+      },
+    })
     const [_date, setDate] = useUncontrolled<DateStringValue>({
       value: computed(() => toDateString(props.date ?? null) ?? undefined),
       defaultValue: toDateString(props.defaultDate ?? null) ?? undefined,
-      finalValue: toDateString(props.value ?? null) || dayjs().format('YYYY-MM-DD'),
+      finalValue: value.value || dayjs().format('YYYY-MM-DD'),
       onChange: (value) => props.onDateChange?.(value),
     })
 
@@ -3017,12 +3108,12 @@ export const MiniCalendar = defineComponent({
             disabled,
             'aria-label': date.format('YYYY-MM-DD'),
             'data-disabled': disabled || undefined,
-            'data-selected': (props.value && dayjs(date).isSame(props.value, 'day')) || undefined,
+            'data-selected': (value.value && dayjs(date).isSame(value.value, 'day')) || undefined,
             ...dayProps,
             class: [classes.miniCalendarDay, dayProps.class],
             onClick: (event: MouseEvent) => {
               dayProps.onClick?.(event)
-              props.onChange?.(toDateString(date.format('YYYY-MM-DD'))!)
+              setValue(toDateString(date.format('YYYY-MM-DD'))!)
             },
           },
           () => [

--- a/packages/@mantine-vue/schedule/src/components/ScheduleHeader/ScheduleHeaderBase.ts
+++ b/packages/@mantine-vue/schedule/src/components/ScheduleHeader/ScheduleHeaderBase.ts
@@ -85,10 +85,7 @@ export const ScheduleHeaderBase = defineComponent({
           size: 'sm',
           data: views.map((view) => ({ value: view, label: getLabel(view, props.labels) })),
           'aria-label': getLabel('viewSelectLabel', props.labels),
-          onChange: (event: Event) =>
-            props.onViewChange?.(
-              (event.currentTarget as HTMLSelectElement).value as ScheduleViewLevel,
-            ),
+          onChange: (value: string) => props.onViewChange?.(value as ScheduleViewLevel),
         }),
         h(Box, { class: classes.viewSelect, style: { marginInlineStart: 'auto' } }, () => [
           h(ScheduleHeader.ViewSelect, {

--- a/packages/@mantine-vue/table/src/components/inputs/MVT_EditCellTextInput.ts
+++ b/packages/@mantine-vue/table/src/components/inputs/MVT_EditCellTextInput.ts
@@ -54,7 +54,7 @@ export const MVT_EditCellTextInput = defineComponent({
         label: modal ? def.header : undefined,
         name: cell.id,
         placeholder: !modal ? def.header : undefined,
-        value: value.value,
+        modelValue: value.value,
         variant: table.options.editDisplayMode === 'table' ? 'unstyled' : 'default',
         onClick: (e: MouseEvent) => e.stopPropagation(),
         ref: setRef,
@@ -64,10 +64,10 @@ export const MVT_EditCellTextInput = defineComponent({
           ...common,
           searchable: true,
           ...selectProps,
-          onChange: (newValue: any, option: any) => {
+          'onUpdate:modelValue': (newValue: any) => {
             value.value = newValue
-            selectProps.onChange?.(newValue, option)
           },
+          onChange: selectProps.onChange,
           onBlur: blur,
         } as any)
       if (def.editVariant === 'multi-select')
@@ -75,20 +75,20 @@ export const MVT_EditCellTextInput = defineComponent({
           ...common,
           searchable: true,
           ...selectProps,
-          onChange: (newValue: any[]) => {
+          'onUpdate:modelValue': (newValue: any[]) => {
             value.value = newValue
-            selectProps.onChange?.(newValue)
           },
+          onChange: selectProps.onChange,
           onBlur: blur,
         } as any)
       return h(TextInput, {
         ...common,
-        value: value.value ?? '',
+        modelValue: value.value ?? '',
         ...textProps,
-        onChange: (event: Event | string) => {
-          value.value = typeof event === 'string' ? event : (event.target as HTMLInputElement).value
-          textProps.onChange?.(event)
+        'onUpdate:modelValue': (nextValue: string) => {
+          value.value = nextValue
         },
+        onChange: textProps.onChange,
         onBlur: blur,
         onKeydown: (event: KeyboardEvent) => {
           textProps.onKeyDown?.(event)

--- a/packages/@mantine-vue/table/src/components/inputs/MVT_FilterCheckbox.ts
+++ b/packages/@mantine-vue/table/src/components/inputs/MVT_FilterCheckbox.ts
@@ -38,11 +38,11 @@ export const MVT_FilterCheckbox = defineComponent({
             size: table.getState().density === 'xs' ? 'sm' : 'md',
             ...checkboxProps,
             title: undefined,
-            onChange: (e: Event) => {
+            onChange: (checked: boolean) => {
               column.setFilterValue(
                 value === undefined ? 'true' : value === 'true' ? 'false' : undefined,
               )
-              checkboxProps.onChange?.(e)
+              checkboxProps.onChange?.(checked)
             },
             onClick: (e: MouseEvent) => {
               e.stopPropagation()

--- a/packages/@mantine-vue/table/src/components/inputs/MVT_SelectCheckbox.ts
+++ b/packages/@mantine-vue/table/src/components/inputs/MVT_SelectCheckbox.ts
@@ -47,13 +47,10 @@ export const MVT_SelectCheckbox = defineComponent({
         size: state.density === 'xs' ? 'sm' : 'md',
         ...checkboxProps,
         title: undefined,
-        onChange: (event: Event) => {
-          event.stopPropagation()
-          if ((event as any).shiftKey === undefined) {
-            ;(event as any).shiftKey = lastShiftKey
-          }
-          selection(event)
-          checkboxProps.onChange?.(event)
+        onChange: (nextChecked: boolean) => {
+          selection({ shiftKey: lastShiftKey } as unknown as Event, nextChecked)
+          checkboxProps.onChange?.(nextChecked)
+          lastShiftKey = false
         },
         onClick: (event: MouseEvent) => {
           event.stopPropagation()


### PR DESCRIPTION
## Summary

This PR standardizes two-way binding across Mantine Vue form controls.

All applicable core and date/time components now support idiomatic Vue 3
`v-model` bindings through the `modelValue` / `update:modelValue` contract.

## Changes

- Added `modelValue` and `update:modelValue` support to text, selection,
  compound, slider, color, file, and date/time controls.
- Preserved legacy controlled props such as `value` and `checked`.
- Preserved uncontrolled usage through `defaultValue` and `defaultChecked`.
- Updated native inputs to bind `value` and `checked` from component state.
- Changed `change` events to emit raw values instead of DOM events.
- Preserved `v-model:checked` compatibility for boolean controls.
- Retained additional selection metadata where applicable, with the raw value
  remaining the first `change` argument.
- Updated examples, documentation, showcases, and internal consumers.
- Added v-model tests covering external model updates and user interactions.

## Breaking changes

The payload of `change` events has changed.

Before:

```vue
<TextInput
  :value="value"
  @change="value = $event.currentTarget.value"
/>

<Checkbox
  :checked="checked"
  @change="checked = $event.target.checked"
/>
```

After:

```vue
<TextInput v-model="value" />
<Checkbox v-model="checked" />
```

Explicit raw-value handlers are also supported:

```vue
<TextInput @change="value = $event" />
<Checkbox @change="checked = $event" />
```

Consumers that rely on native DOM events from component-level `change`
handlers must migrate to raw-value handlers.

## Compatibility

The following patterns remain supported:

- `value` with `@change`
- `checked` with `@change`
- `defaultValue`
- `defaultChecked`
- `v-model:checked` for boolean controls

Visual, layout, accessibility, and Styles API props remain unchanged.