### PR TITLE
[release] Version: 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-vue",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "private": true,
   "description": "Mantine vue Components Monorepo ported of Mantine React",
   "license": "MIT",

--- a/packages/@mantine-vue/carousel/package.json
+++ b/packages/@mantine-vue/carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/carousel",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Embla based carousel, Vue equivalent to @mantine/carousel",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "embla-carousel": ">=8.0.0",
     "embla-carousel-vue": ">=8.0.0",
     "vue": "^3.5.0"

--- a/packages/@mantine-vue/charts/package.json
+++ b/packages/@mantine-vue/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/charts",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Charts components built with Apache ECharts and Mantine Vue",
   "license": "MIT",
   "files": [
@@ -38,7 +38,7 @@
     "vue-echarts": "^8.0.1"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
     "echarts": ">=6.0.0",
     "vue": "^3.5.0",
     "vue-echarts": ">=8.0.0"

--- a/packages/@mantine-vue/code-highlight/package.json
+++ b/packages/@mantine-vue/code-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/code-highlight",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue code highlight components equivalent to @mantine/code-highlight",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/colors-generator/package.json
+++ b/packages/@mantine-vue/colors-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/colors-generator",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "A library to generate 10 shades of color based on provided color value",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/contextmenu/package.json
+++ b/packages/@mantine-vue/contextmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/contextmenu",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Desktop-grade context menu extension for Mantine Vue",
   "license": "MIT",
   "files": [
@@ -39,8 +39,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "vue": "^3.5.0"
   },
   "mantineVue": {

--- a/packages/@mantine-vue/core/package.json
+++ b/packages/@mantine-vue/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/core",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue component foundation architecturally equivalent to @mantine/core",
   "license": "MIT",
   "files": [
@@ -44,8 +44,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/hooks": "2.4.0",
-    "@mantine-vue/utils": "2.4.0",
+    "@mantine-vue/hooks": "3.0.0",
+    "@mantine-vue/utils": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/dates/package.json
+++ b/packages/@mantine-vue/dates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/dates",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue date and time picker components equivalent to @mantine/dates",
   "license": "MIT",
   "files": [
@@ -40,8 +40,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "dayjs": ">=1.0.0",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/dropzone/package.json
+++ b/packages/@mantine-vue/dropzone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/dropzone",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue file drag & drop zone component equivalent to @mantine/dropzone",
   "license": "MIT",
   "files": [
@@ -37,8 +37,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/form/package.json
+++ b/packages/@mantine-vue/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/form",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue form management package equivalent to @mantine/form",
   "license": "MIT",
   "files": [
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@mantine-vue/utils": "2.4.0"
+    "@mantine-vue/utils": "3.0.0"
   },
   "devDependencies": {
     "@mantine-vue/utils": "workspace:*",

--- a/packages/@mantine-vue/hooks/package.json
+++ b/packages/@mantine-vue/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/hooks",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue composables equivalent to @mantine/hooks",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/mantine-header/package.json
+++ b/packages/@mantine-vue/mantine-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/mantine-header",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Components used in headers of *.mantine.dev websites (Vue port of @mantinex/mantine-header)",
   "license": "MIT",
   "files": [
@@ -35,7 +35,7 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
     "@phosphor-icons/vue": "^2.2",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/modals/package.json
+++ b/packages/@mantine-vue/modals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/modals",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue modals management system equivalent to @mantine/modals",
   "license": "MIT",
   "files": [
@@ -35,8 +35,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/store": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/store": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/notifications/package.json
+++ b/packages/@mantine-vue/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/notifications",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue notifications system equivalent to @mantine/notifications",
   "license": "MIT",
   "files": [
@@ -40,9 +40,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
-    "@mantine-vue/store": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
+    "@mantine-vue/store": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/nprogress/package.json
+++ b/packages/@mantine-vue/nprogress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/nprogress",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue navigation progress bar equivalent to @mantine/nprogress",
   "license": "MIT",
   "files": [
@@ -37,8 +37,8 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/store": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/store": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/schedule/package.json
+++ b/packages/@mantine-vue/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/schedule",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue schedule and calendar components equivalent to @mantine/schedule",
   "license": "MIT",
   "files": [
@@ -44,9 +44,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/dates": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/dates": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "dayjs": ">=1.0.0",
     "vue": "^3.5.0"
   }

--- a/packages/@mantine-vue/spotlight/package.json
+++ b/packages/@mantine-vue/spotlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/spotlight",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue command center components equivalent to @mantine/spotlight",
   "license": "MIT",
   "files": [
@@ -36,9 +36,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
-    "@mantine-vue/store": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
+    "@mantine-vue/store": "3.0.0",
     "vue": "^3.5.0"
   }
 }

--- a/packages/@mantine-vue/store/package.json
+++ b/packages/@mantine-vue/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/store",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "External store primitive for later extension packages",
   "license": "MIT",
   "files": [

--- a/packages/@mantine-vue/table/package.json
+++ b/packages/@mantine-vue/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/table",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "A fully featured Vue 3 implementation of TanStack Vue Table",
   "keywords": [
     "data grid",
@@ -65,9 +65,9 @@
     "vue": "^3.5.0"
   },
   "peerDependencies": {
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/dates": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/dates": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "@tabler/icons-vue": ">=3.0.0",
     "@tanstack/match-sorter-utils": ">=8.7",
     "@tanstack/vue-table": ">=8.20",

--- a/packages/@mantine-vue/tiptap/package.json
+++ b/packages/@mantine-vue/tiptap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/tiptap",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Vue rich text editor based on tiptap, equivalent to @mantine/tiptap",
   "license": "MIT",
   "files": [
@@ -45,8 +45,8 @@
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.0.0",
-    "@mantine-vue/core": "2.4.0",
-    "@mantine-vue/hooks": "2.4.0",
+    "@mantine-vue/core": "3.0.0",
+    "@mantine-vue/hooks": "3.0.0",
     "@tiptap/core": ">=3.3.0",
     "@tiptap/extension-link": ">=3.3.0",
     "@tiptap/pm": ">=3.3.0",

--- a/packages/@mantine-vue/utils/package.json
+++ b/packages/@mantine-vue/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantine-vue/utils",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Framework-independent utilities ported from Mantine foundation",
   "license": "MIT",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,8 +562,8 @@ __metadata:
     embla-carousel-vue: "npm:^8.6.0"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     embla-carousel: ">=8.0.0"
     embla-carousel-vue: ">=8.0.0"
     vue: ^3.5.0
@@ -579,7 +579,7 @@ __metadata:
     vue: "npm:^3.5.0"
     vue-echarts: "npm:^8.0.1"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/core": 3.0.0
     echarts: ">=6.0.0"
     vue: ^3.5.0
     vue-echarts: ">=8.0.0"
@@ -596,8 +596,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -623,8 +623,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -641,8 +641,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/hooks": 2.4.0
-    "@mantine-vue/utils": 2.4.0
+    "@mantine-vue/hooks": 3.0.0
+    "@mantine-vue/utils": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -658,8 +658,8 @@ __metadata:
     dayjs: "npm:^1.11.21"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     dayjs: ">=1.0.0"
     vue: ^3.5.0
   languageName: unknown
@@ -746,8 +746,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -782,7 +782,7 @@ __metadata:
     "@phosphor-icons/vue": "npm:^2.2"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
+    "@mantine-vue/core": 3.0.0
     "@phosphor-icons/vue": ^2.2
     vue: ^3.5.0
   languageName: unknown
@@ -798,8 +798,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/store": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/store": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -815,9 +815,9 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
-    "@mantine-vue/store": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
+    "@mantine-vue/store": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -832,8 +832,8 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/store": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/store": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -851,9 +851,9 @@ __metadata:
     rrule: "npm:^2.8.1"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/dates": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/dates": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     dayjs: ">=1.0.0"
     vue: ^3.5.0
   languageName: unknown
@@ -921,9 +921,9 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
-    "@mantine-vue/store": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
+    "@mantine-vue/store": 3.0.0
     vue: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -955,9 +955,9 @@ __metadata:
     dayjs: "npm:^1.11.21"
     vue: "npm:^3.5.0"
   peerDependencies:
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/dates": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/dates": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     "@tabler/icons-vue": ">=3.0.0"
     "@tanstack/match-sorter-utils": ">=8.7"
     "@tanstack/vue-table": ">=8.20"
@@ -984,8 +984,8 @@ __metadata:
     vue: "npm:^3.5.0"
   peerDependencies:
     "@floating-ui/dom": ^1.0.0
-    "@mantine-vue/core": 2.4.0
-    "@mantine-vue/hooks": 2.4.0
+    "@mantine-vue/core": 3.0.0
+    "@mantine-vue/hooks": 3.0.0
     "@tiptap/core": ">=3.3.0"
     "@tiptap/extension-link": ">=3.3.0"
     "@tiptap/pm": ">=3.3.0"


### PR DESCRIPTION
# Mantine Vue 3.0.0

## Summary

Mantine Vue 3.0.0 standardizes two-way binding across form controls.

All applicable core and date/time components now support idiomatic Vue 3
`v-model` bindings through the `modelValue` / `update:modelValue` contract.

## Changes

- Added `modelValue` and `update:modelValue` support to text, selection,
  compound, slider, color, file, and date/time controls.
- Preserved legacy controlled props such as `value` and `checked`.
- Preserved uncontrolled usage through `defaultValue` and `defaultChecked`.
- Updated native inputs to bind `value` and `checked` from component state.
- Changed `change` events to emit raw values instead of DOM events.
- Preserved `v-model:checked` compatibility for boolean controls.
- Retained additional selection metadata where applicable, with the raw value
  remaining the first `change` argument.
- Updated examples, documentation, showcases, and internal consumers.
- Added v-model tests covering external model updates and user interactions.

## Breaking changes

The payload of `change` events has changed.

Before:

```vue
<TextInput
  :value="value"
  @change="value = $event.currentTarget.value"
/>

<Checkbox
  :checked="checked"
  @change="checked = $event.target.checked"
/>
```

After:

```vue
<TextInput v-model="value" />
<Checkbox v-model="checked" />
```

Explicit raw-value handlers are also supported:

```vue
<TextInput @change="value = $event" />
<Checkbox @change="checked = $event" />
```

Consumers that rely on native DOM events from component-level `change`
handlers must migrate to raw-value handlers.

## Compatibility

The following patterns remain supported:

- `value` with `@change`
- `checked` with `@change`
- `defaultValue`
- `defaultChecked`
- `v-model:checked` for boolean controls

Visual, layout, accessibility, and Styles API props remain unchanged.
